### PR TITLE
fix: update gamified ABM compliance sheet URL

### DIFF
--- a/inst/dashboard/index.qmd
+++ b/inst/dashboard/index.qmd
@@ -733,7 +733,8 @@ if (!is.null(enrollment_stats$monthly_breakdown) && nrow(enrollment_stats$monthl
 ```{r}
 # Get gamified ABM compliance
 gabm_compliance <- tryCatch({
-  gabm_sheet_url <- "https://docs.google.com/spreadsheets/d/1Sz3BOKVIx4TQbMfRpgYIc_Cyt-p5dU1S1DKGr-yaLmk/edit?gid=0#gid=0"
+  # Updated 2026-07-08: Arcade Therapeutics created new sheet after system update on 2025-04-16 caused data sync outage. Old sheet kept as archive.
+  gabm_sheet_url <- "https://docs.google.com/spreadsheets/d/1ff90Q2V_WoKm2Rw7w1Ur0UrNIsmxu5TEWPoPcNtooHE/edit?gid=0#gid=0"
 
   # Get the compliance data
   result <- abmdash::get_participant_summary(gabm_sheet_url)


### PR DESCRIPTION
## Summary

Updated the gamified ABM (GABM) compliance Google Sheet URL in `inst/dashboard/index.qmd` to point to a new sheet created by Arcade Therapeutics.

## Background

Arcade Therapeutics updated their system on April 16, 2025, which caused a data sync outage. They created a new Google Sheet with corrected data — fixing duplicate events and missing assessments. The old sheet is kept as an archive.

## Changes

- **File:** `inst/dashboard/index.qmd` (line 736)
- Replaced old sheet ID `1Sz3BOKVIx4TQbMfRpgYIc_Cyt-p5dU1S1DKGr-yaLmk` with new sheet ID `1ff90Q2V_WoKm2Rw7w1Ur0UrNIsmxu5TEWPoPcNtooHE`
- Added a comment documenting the reason for the change and date

## Verification

Ran a verification script (not committed) using `abmdash::read_google_sheet()` with the new URL:

- **Sheet accessible:** yes — service account `calendar-reader@gothic-calling-469320-h0.iam.gserviceaccount.com` has access
- **Data present:** 3169 rows × 15 columns
- **Expected columns all present:** `Referral ID`, `Date of Event UTC`, `Event Type`, `Week #`, `Session #`, `Turns Completed` (matches what `get_compliance_report()` reads)
- **First tab name:** `Sheet1` (matches the default `read_google_sheet` uses when no `sheet_name` is specified)
- **First few rows:** contain real participant data (Registration and Assessment events)

## Test plan

- [x] New sheet URL verified accessible via service account
- [x] Column structure matches `get_compliance_report()` expectations
- [x] First tab is `Sheet1` (matches default read behavior)
- [ ] Dashboard renders correctly with new data (verify after merge)