### PR TITLE
[fix] NA-safe eligibility filtering in get_eligible_participants (#38)

### DIFF
--- a/R/redcap_api.R
+++ b/R/redcap_api.R
@@ -430,7 +430,12 @@ get_eligible_participants <- function() {
     
     recent_count <- nrow(recent_records)
     
-    # Apply eligibility criteria to recent records
+    # Apply eligibility criteria to recent records.
+    # Parse phq8score once: as.numeric() yields NA for empty/unparseable
+    # values, and an NA in the row index would leak an all-NA row into the
+    # result (and later crash data.frame() with "row names contain missing
+    # values"), so guard on the parsed value, not the raw string.
+    phq8score_num <- suppressWarnings(as.numeric(recent_records$phq8score))
     eligible_participants <- recent_records[
       !is.na(recent_records$r01es_commute) & recent_records$r01es_commute == "1" &
       !is.na(recent_records$r01es_austin) & recent_records$r01es_austin == "1" &
@@ -438,15 +443,15 @@ get_eligible_participants <- function() {
       !is.na(recent_records$r01es_computer) & recent_records$r01es_computer == "1" &
       !is.na(recent_records$r01es_bpd) & recent_records$r01es_bpd == "0" &
       !is.na(recent_records$r01es_psychotherapy) & recent_records$r01es_psychotherapy == "0" &
-      !is.na(recent_records$phq8score) & as.numeric(recent_records$phq8score) >= 17 &
+      !is.na(phq8score_num) & phq8score_num >= 17 &
       !is.na(recent_records$r01es_druguse) & recent_records$r01es_druguse == "0" &
       !is.na(recent_records$medchng) & recent_records$medchng == "0" &
       !is.na(recent_records$r01es_medstop) & recent_records$r01es_medstop == "0" &
       !is.na(recent_records$r01es_medstart) & recent_records$r01es_medstart == "0",
     ]
-    
+
     eligible_count <- nrow(eligible_participants)
-    
+
     # If no eligible participants, return summary
     if (eligible_count == 0) {
       return(data.frame(
@@ -458,7 +463,10 @@ get_eligible_participants <- function() {
       ))
     }
     
-    # Extract first name from the r01es_name field
+    # Extract first name from the r01es_name field.
+    # USE.NAMES = FALSE: sapply would otherwise name the result with the full
+    # name values; an NA name value is then promoted to a row name by
+    # data.frame() below and raises "row names contain missing values".
     first_names <- sapply(eligible_participants$r01es_name, function(full_name) {
       if (is.null(full_name) || is.na(full_name) || full_name == "") {
         return("Unknown")
@@ -466,7 +474,7 @@ get_eligible_participants <- function() {
       # Get the first word (before first space)
       first_word <- sub("\\s.*", "", full_name)
       return(first_word)
-    })
+    }, USE.NAMES = FALSE)
 
     # Return the specific columns for eligible participants
     result <- data.frame(
@@ -552,7 +560,11 @@ get_weekly_screening_stats <- function() {
 
     total_screenings <- nrow(recent_records)
 
-    # Apply eligibility criteria to recent records
+    # Apply eligibility criteria to recent records.
+    # Parse phq8score once and guard on the parsed value: as.numeric() yields
+    # NA for empty/unparseable values, and an NA in the row index would insert
+    # an all-NA row that inflates eligible_count.
+    phq8score_num <- suppressWarnings(as.numeric(recent_records$phq8score))
     eligible_participants <- recent_records[
       !is.na(recent_records$r01es_commute) & recent_records$r01es_commute == "1" &
       !is.na(recent_records$r01es_austin) & recent_records$r01es_austin == "1" &
@@ -560,7 +572,7 @@ get_weekly_screening_stats <- function() {
       !is.na(recent_records$r01es_computer) & recent_records$r01es_computer == "1" &
       !is.na(recent_records$r01es_bpd) & recent_records$r01es_bpd == "0" &
       !is.na(recent_records$r01es_psychotherapy) & recent_records$r01es_psychotherapy == "0" &
-      !is.na(recent_records$phq8score) & as.numeric(recent_records$phq8score) >= 17 &
+      !is.na(phq8score_num) & phq8score_num >= 17 &
       !is.na(recent_records$r01es_druguse) & recent_records$r01es_druguse == "0" &
       !is.na(recent_records$medchng) & recent_records$medchng == "0" &
       !is.na(recent_records$r01es_medstop) & recent_records$r01es_medstop == "0" &

--- a/docs/evidence/38/01-test-red-before-fix.txt
+++ b/docs/evidence/38/01-test-red-before-fix.txt
@@ -1,0 +1,48 @@
+✔ | F W  S  OK | Context
+
+⠏ |          0 | eligible-participants                                          
+⠇ | 3        6 | eligible-participants                                          
+✖ | 3       16 | eligible-participants
+────────────────────────────────────────────────────────────────────────────────
+Failure ('test-eligible-participants.R:79:3'): get_eligible_participants excludes records with empty/unparseable phq8score
+"first_name" %in% names(result) is not TRUE
+
+`actual`:   FALSE
+`expected`: TRUE 
+
+Failure ('test-eligible-participants.R:81:3'): get_eligible_participants excludes records with empty/unparseable phq8score
+result$first_name (`actual`) not equal to "Alice" (`expected`).
+
+`actual` is NULL
+`expected` is a character vector ('Alice')
+
+Failure ('test-eligible-participants.R:82:3'): get_eligible_participants excludes records with empty/unparseable phq8score
+result$phone_number (`actual`) not equal to "5120000000" (`expected`).
+
+`actual` is NULL
+`expected` is a character vector ('5120000000')
+────────────────────────────────────────────────────────────────────────────────
+
+══ Results ═════════════════════════════════════════════════════════════════════
+── Failed tests ────────────────────────────────────────────────────────────────
+Failure ('test-eligible-participants.R:79:3'): get_eligible_participants excludes records with empty/unparseable phq8score
+"first_name" %in% names(result) is not TRUE
+
+`actual`:   FALSE
+`expected`: TRUE 
+
+Failure ('test-eligible-participants.R:81:3'): get_eligible_participants excludes records with empty/unparseable phq8score
+result$first_name (`actual`) not equal to "Alice" (`expected`).
+
+`actual` is NULL
+`expected` is a character vector ('Alice')
+
+Failure ('test-eligible-participants.R:82:3'): get_eligible_participants excludes records with empty/unparseable phq8score
+result$phone_number (`actual`) not equal to "5120000000" (`expected`).
+
+`actual` is NULL
+`expected` is a character vector ('5120000000')
+
+[ FAIL 3 | WARN 0 | SKIP 0 | PASS 16 ]
+Error: Test failures
+Execution halted

--- a/docs/evidence/38/02-test-green-after-fix.txt
+++ b/docs/evidence/38/02-test-green-after-fix.txt
@@ -1,0 +1,7 @@
+✔ | F W  S  OK | Context
+
+⠏ |          0 | eligible-participants                                          
+✔ |         19 | eligible-participants
+
+══ Results ═════════════════════════════════════════════════════════════════════
+[ FAIL 0 | WARN 0 | SKIP 0 | PASS 19 ]

--- a/docs/evidence/38/03-full-suite.txt
+++ b/docs/evidence/38/03-full-suite.txt
@@ -1,0 +1,17 @@
+✔ | F W  S  OK | Context
+
+⠏ |          0 | combined-calendar                                              Warning: failed to fetch calendar cal_broken: API error for this calendar
+
+✔ |          8 | combined-calendar
+
+⠏ |          0 | eligible-participants                                          
+✔ |         19 | eligible-participants
+
+⠏ |          0 | run-initial-function                                           
+✔ |          1 | run-initial-function
+
+⠏ |          0 | trad-compliance                                                
+✔ |         11 | trad-compliance
+
+══ Results ═════════════════════════════════════════════════════════════════════
+[ FAIL 0 | WARN 0 | SKIP 0 | PASS 39 ]

--- a/docs/evidence/38/04-e2e-live-api-after-fix.txt
+++ b/docs/evidence/38/04-e2e-live-api-after-fix.txt
@@ -1,0 +1,14 @@
+Status column present (TRUE means error/summary frame): FALSE 
+Rows: 5 
+  first_name   phone_number interview_date
+1     Samuel (512) 350-3071     2026-07-14
+2   Michelle (210) 386-7887     2026-07-15
+3      Megan (512) 803-9646     2026-07-23
+4      Nitra (512) 575-3292     2026-07-28
+5       Eric (847) 561-0561     2026-08-02
+                                                                                     link_to_record_id
+1 https://redcap.prc.utexas.edu/redcap/redcap_v15.5.6/DataEntry/record_home.php?pid=3385&arm=1&id=3156
+2 https://redcap.prc.utexas.edu/redcap/redcap_v15.5.6/DataEntry/record_home.php?pid=3385&arm=1&id=3164
+3 https://redcap.prc.utexas.edu/redcap/redcap_v15.5.6/DataEntry/record_home.php?pid=3385&arm=1&id=3192
+4 https://redcap.prc.utexas.edu/redcap/redcap_v15.5.6/DataEntry/record_home.php?pid=3385&arm=1&id=3205
+5 https://redcap.prc.utexas.edu/redcap/redcap_v15.5.6/DataEntry/record_home.php?pid=3385&arm=1&id=3212

--- a/docs/evidence/38/04-e2e-live-api-before-fix.txt
+++ b/docs/evidence/38/04-e2e-live-api-before-fix.txt
@@ -1,0 +1,18 @@
+E2E run against LIVE REDCap report 14081 with the pre-fix installed package
+(R/redcap_api.R @ 1b874dd). Exact production symptom reproduced:
+
+  === Running get_eligible_participants() ===
+                                   Status Total_Records Eligible_Count
+1 Error: row names contain missing values             0              0
+
+Status frame (not participant data): Total_Records 0, Eligible_Count 0 —
+matches the dashboard screenshot in issue #38.
+
+Underlying trace (same run, pre-fix code paths exercised step by step):
+  report_df nrow: 83, ncol: 1388      (raw report 14081)
+  recent_records nrow: 61             (30-day window; NA dates already excluded)
+  phq8score as.numeric NA count: 21   (empty-string scores: as.numeric("") = NA)
+  full eligibility condition NA count: 1  (NA leaked into the row index)
+  eligible nrow: 6 with one all-NA row inserted (row name "NA")
+  sapply(USE.NAMES=TRUE) names: ... | NA | ...  (real NA name value)
+  data.frame() -> ERROR: row names contain missing values

--- a/docs/evidence/38/REPORT.md
+++ b/docs/evidence/38/REPORT.md
@@ -1,0 +1,58 @@
+# Evidence — Issue #38: "row names contain missing values" in Recent Eligible Participants
+
+**Date:** 2026-08-12 · **Branch:** `38-fix-recent-eligible-NA` · **Base:** `origin/main` (1b874dd)
+
+## Root cause (confirmed empirically, R 4.5.1 — same version as the Docker deploy)
+
+The issue's hypothesis pointed at the 30-day `interview_date` filter
+(`R/redcap_api.R:422-426`), but that filter **already contains a `!is.na()`
+guard** and was verified NOT to be the failing line. Live reproduction against
+REDCap report 14081 (83 records) pinned the real chain:
+
+1. **`R/redcap_api.R:441` (eligibility filter):** `!is.na(recent_records$phq8score) & as.numeric(recent_records$phq8score) >= 17` guards the *raw string* but not the *parsed value*. REDCap returns unset fields as `""`; `as.numeric("")` is `NA`, so the guard is `TRUE & NA = NA` and the logical row index contains NA. `[.data.frame` does not error — it inserts an all-NA row (row name coerced to the string `"NA"`).
+2. **`R/redcap_api.R:462` (first name extraction):** `sapply(eligible_participants$r01es_name, ...)` with default `USE.NAMES = TRUE` names the result with the full-name *values*; the all-NA row's value is a real `NA`.
+3. **`R/redcap_api.R:472-479` (result construction):** `data.frame(first_name = first_names, ...)` promotes those names to row names; base R's `data.frame()` raises **"row names contain missing values"** (`anyNA(row.names)` check, R source line 154 of `data.frame`). The function's internal `tryCatch` converts that into the summary frame `Status = "Error: row names contain missing values"`, `Total_Records = 0`, `Eligible_Count = 0` — the exact production output.
+
+Relevant real-data facts: 21 of 61 recent records have empty `phq8score`; one
+of those passes every other criterion, so one NA row leaked.
+
+## Fix (R/redcap_api.R)
+
+| Location | Before | After |
+|---|---|---|
+| `get_eligible_participants`, eligibility filter | `!is.na(recent_records$phq8score) & as.numeric(recent_records$phq8score) >= 17` | parse once + guard parsed value: `phq8score_num <- suppressWarnings(as.numeric(...))` then `!is.na(phq8score_num) & phq8score_num >= 17` |
+| `get_eligible_participants`, first names | `sapply(eligible_participants$r01es_name, ...)` | `sapply(..., USE.NAMES = FALSE)` — stops the name→row-name promotion entirely |
+| `get_weekly_screening_stats`, eligibility filter | same raw-string guard as above | same parsed-value guard (sibling function, same bug: silently inflated `eligible_count` by 1) |
+
+The 30-day date filter was left untouched — it was already NA-safe.
+
+## Evidence files
+
+- `01-test-red-before-fix.txt` — testthat output on the un-fixed code: test 2
+  (`get_eligible_participants excludes records with empty/unparseable
+  phq8score`) fails; the function returns the error summary frame instead of
+  participant data (`"first_name" %in% names(result)` is `FALSE`).
+- `02-test-green-after-fix.txt` — same tests after the fix: 19 pass, 0 fail.
+- `03-full-suite.txt` — full `testthat::test_local()`: 39 pass, 0 fail.
+- `04-e2e-live-api-before-fix.txt` — live REDCap run, pre-fix package: exact
+  production error frame + step trace.
+- `04-e2e-live-api-after-fix.txt` — live REDCap run, post-fix package: 5 real
+  eligible participants (First Name / Phone / Screen Date / Link), no error.
+
+## Test coverage added (tests/testthat/test-eligible-participants.R)
+
+Mocking the HTTP boundary per existing convention (`local_mocked_bindings` on
+`get_redcap_report`, REDCap-shaped list-of-lists fixtures):
+
+1. NA / unparseable `interview_date` records are excluded, not crashed on.
+2. **Regression for #38:** empty `phq8score` record excluded — participant data
+   returned, no error frame, no garbage all-NA row (`Unknown`/`NA` phone/`id=NA` link).
+3. No eligible records → summary frame with `Eligible_Count = 0`.
+4. Empty report → summary frame with `Total_Records = 0`.
+
+## Spec conformance
+
+- AC "no longer errors with row names contain missing values": covered by test 2 + live-API run.
+- AC "table renders eligible participants": live-API run returns 5 rows with all 4 columns.
+- AC "NA/unparseable interview_date handled safely": covered by test 1 (guard pre-existed; now pinned).
+- AC "unit test added": tests/testthat/test-eligible-participants.R (4 tests).

--- a/tests/testthat/test-eligible-participants.R
+++ b/tests/testthat/test-eligible-participants.R
@@ -1,0 +1,116 @@
+# Unit tests for get_eligible_participants()
+#
+# Regression tests for #38: "Error: row names contain missing values" in the
+# Recent Eligible Participants dashboard table. The error was raised by
+# data.frame() when a record with an empty/unparseable phq8score ("") slipped
+# through the eligibility filter as an NA row: as.numeric("") is NA, so the
+# logical row index contained NA, [.data.frame inserted an all-NA row, and the
+# sapply(USE.NAMES=TRUE) + data.frame() construction promoted the NA row name
+# into "row names contain missing values".
+#
+# All tests mock the REDCap HTTP boundary (get_redcap_report) with
+# REDCap-shaped JSON data: a list of named lists, character scalars, "" for
+# unset fields, "YYYY-MM-DD" interview dates.
+
+# Build a REDCap-shaped record list with the fields get_eligible_participants
+# actually reads. All eligibility fields default to "1" (eligible) so a test can
+# exercise one field at a time.
+eligible_record <- function(record_id,
+                            interview_date = format(Sys.Date() - 2, "%Y-%m-%d"),
+                            phq8score = "20",
+                            r01es_name = "Test Person") {
+  list(
+    record_id = record_id,
+    interview_date = interview_date,
+    r01es_name = r01es_name,
+    r01es_phonenumber = "5120000000",
+    r01es_commute = "1",
+    r01es_austin = "1",
+    r01es_phone = "1",
+    r01es_computer = "1",
+    r01es_bpd = "0",
+    r01es_psychotherapy = "0",
+    phq8score = phq8score,
+    r01es_druguse = "0",
+    medchng = "0",
+    r01es_medstop = "0",
+    r01es_medstart = "0"
+  )
+}
+
+test_that("get_eligible_participants excludes records with missing interview_date", {
+  local_mocked_bindings(
+    get_redcap_report = function(report_id, ...) {
+      list(
+        eligible_record("1"),                       # valid, recent
+        eligible_record("2", interview_date = NA),   # NA interview_date
+        eligible_record("3", interview_date = "")    # unparseable interview_date
+      )
+    }
+  )
+
+  result <- get_eligible_participants()
+
+  expect_s3_class(result, "data.frame")
+  expect_true("first_name" %in% names(result))
+  # NA/empty interview_date records are excluded, not crashed on
+  expect_equal(nrow(result), 1)
+  expect_equal(result$first_name, "Test")
+  expect_equal(result$link_to_record_id, "https://redcap.prc.utexas.edu/redcap/redcap_v15.5.6/DataEntry/record_home.php?pid=3385&arm=1&id=1")
+})
+
+test_that("get_eligible_participants excludes records with empty/unparseable phq8score", {
+  local_mocked_bindings(
+    get_redcap_report = function(report_id, ...) {
+      list(
+        eligible_record("1", phq8score = "20", r01es_name = "Alice Alpha"),
+        eligible_record("2", phq8score = "", r01es_name = "Bob Beta")
+      )
+    }
+  )
+
+  # Regression for #38: previously the empty phq8score leaked an NA row into
+  # the eligibility filter (as.numeric("") is NA) and data.frame() then raised
+  # "row names contain missing values", so the function returned the error
+  # summary frame instead of participant data.
+  result <- get_eligible_participants()
+
+  # Participant data must be returned, not the error summary frame
+  expect_true("first_name" %in% names(result))
+  expect_equal(nrow(result), 1)
+  expect_equal(result$first_name, "Alice")
+  expect_equal(result$phone_number, "5120000000")
+  # No garbage all-NA row (first_name "Unknown", NA phone, id=NA link)
+  expect_false(any(result$first_name == "Unknown"))
+  expect_false(anyNA(result$phone_number))
+  expect_false(any(grepl("id=NA$", result$link_to_record_id)))
+})
+
+test_that("get_eligible_participants returns summary frame when no records are eligible", {
+  local_mocked_bindings(
+    get_redcap_report = function(report_id, ...) {
+      list(
+        eligible_record("1", phq8score = "5")  # below the >= 17 cutoff
+      )
+    }
+  )
+
+  result <- get_eligible_participants()
+
+  expect_s3_class(result, "data.frame")
+  expect_true("Status" %in% names(result))
+  expect_equal(result$Eligible_Count, 0)
+})
+
+test_that("get_eligible_participants returns summary frame when report has no rows", {
+  local_mocked_bindings(
+    get_redcap_report = function(report_id, ...) list()
+  )
+
+  result <- get_eligible_participants()
+
+  expect_s3_class(result, "data.frame")
+  expect_true("Status" %in% names(result))
+  expect_equal(result$Total_Records, 0)
+  expect_equal(result$Eligible_Count, 0)
+})

--- a/tests/testthat/test-eligible-participants.R
+++ b/tests/testthat/test-eligible-participants.R
@@ -114,3 +114,30 @@ test_that("get_eligible_participants returns summary frame when report has no ro
   expect_equal(result$Total_Records, 0)
   expect_equal(result$Eligible_Count, 0)
 })
+
+test_that("get_weekly_screening_stats excludes records with empty phq8score", {
+  # #38 corrected diagnosis: root cause was phq8score "" -> NA row leak, NOT
+  # interview_date as the issue ACs originally hypothesized.
+  local_mocked_bindings(
+    get_redcap_report = function(report_id, ...) {
+      list(
+        eligible_record("1", phq8score = "20"),  # eligible (>= 17 cutoff)
+        eligible_record("2", phq8score = "")     # empty phq8score
+      )
+    }
+  )
+
+  result <- get_weekly_screening_stats()
+
+  # Structure consumed by inst/dashboard/index.qmd "Screening Summary
+  # (Past 7 Days)" card (index.qmd:486-517): a one-row data.frame whose
+  # eligible_count column feeds the "Eligible Participants" row.
+  expect_s3_class(result, "data.frame")
+  expect_equal(names(result), c("total_screenings", "eligible_count", "hispanic_count"))
+  expect_equal(nrow(result), 1)
+  expect_equal(result$total_screenings, 2)
+  # Empty-phq8score record must NOT count: pre-fix code leaked an all-NA row
+  # (as.numeric("") is NA in the row index) that inflated eligible_count to 2.
+  expect_equal(result$eligible_count, 1)
+  expect_equal(result$hispanic_count, 0)
+})


### PR DESCRIPTION
## Summary

Fixes the "Recent Eligible Participants (Check if Scheduled)" dashboard table showing `Error: row names contain missing values` (Total_Records: 0, Eligible_Count: 0).

**Root cause (confirmed against live REDCap report 14081, R 4.5.1 — same version as the Docker deploy):** the issue's hypothesis pointed at the 30-day `interview_date` filter, but that filter already has a `!is.na()` guard and is NOT the failing line. The real chain:

1. `R/redcap_api.R:441` eligibility filter: `!is.na(phq8score) & as.numeric(phq8score) >= 17` guards the raw string but not the parsed value. REDCap returns unset fields as `""`; `as.numeric("")` is `NA` → NA leaks into the logical row index → `[.data.frame` inserts an all-NA row (21 of 61 recent records have empty `phq8score`; 1 passes all other criteria).
2. `R/redcap_api.R:462`: `sapply(..., USE.NAMES = TRUE)` names the result with the full-name values; the all-NA row's value is a real `NA`.
3. `R/redcap_api.R:472-479`: `data.frame(first_name = first_names, ...)` promotes those names to row names → base R raises **"row names contain missing values"** → the function's `tryCatch` surfaces it as the error summary frame.

**Fix:**
- Parse `phq8score` once (`suppressWarnings(as.numeric(...))`) and guard on the parsed value in the eligibility filter — both in `get_eligible_participants()` and its sibling `get_weekly_screening_stats()` (same bug, silently inflated `eligible_count`).
- `sapply(..., USE.NAMES = FALSE)` so name values can never become row names.
- The date filter was left untouched (already NA-safe).

## Issue
Closes #38

## ACs implemented
- [x] `get_eligible_participants()` no longer errors with "row names contain missing values" when any record's data is missing/NA
- [x] Function returns eligible participants (First Name / Phone / Screen Date / Link) — verified live against REDCap: 5 eligible rows returned
- [x] NA/unparseable records handled safely (excluded, not crash) — `interview_date` NA/unparseable and `phq8score` empty/unparseable both pinned by tests
- [x] Unit tests added covering the NA cases (`tests/testthat/test-eligible-participants.R`, previously no coverage)

## Test plan
- [x] New tests: 19 pass (4 new tests; red-before-fix evidence captured)
- [x] Full suite `testthat::test_local()`: 39 pass, 0 fail
- [x] E2E live-API run pre/post fix: error frame → 5 participant rows (`docs/evidence/38/`)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (data-processing fix — test + live-API evidence)
- [x] Design intent respected
- [x] No scope creep