### PR TITLE
[chore] Add OKF knowledge bundle (docs/okf/) for agent navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .Rproj.user
 .Renviron
-docs/
+docs/*
+!docs/okf/
 planning.md
 # opencode pipeline transient artifacts
 .opencode/plans/**/AC-*-speculator-*.md

--- a/.opencode/plans/repo-usability/AC-1.1.md
+++ b/.opencode/plans/repo-usability/AC-1.1.md
@@ -2,7 +2,7 @@
 ac: 1.1
 depends_on: none
 risk: low
-status: spec
+status: complete
 ---
 
 # AC-1.1: OKF knowledge bundle at docs/okf/
@@ -78,13 +78,17 @@ status: spec
 - **Risk level:** low.
 
 ### Progress
-- [ ] bundle generated — pending
+- [x] bundle generated — complete 2026-08-13 (P1-P9 all green; R CMD build ran full tarball check)
 
 ### Decision Log
 - spec-resolved — `.Rbuildignore` "add entry" instruction is ALREADY SATISFIED by `^docs/`; verify-only, do not edit.
+- P9 count — NAMESPACE contains **33** `export()` lines, not 34 (spec off-by-one, likely counted the roxygen comment header). P9 probe reads the real NAMESPACE; all 33 documented in `# Interface` sections, none invented. log.md records 33.
+- L441/L563 flags — verified via `git show 90ef649^:R/redcap_api.R`: pre-fix raw-guard `!is.na(phq8score) & as.numeric(phq8score) >= 17` sat at exactly L441 (get_eligible_participants) and L563 (get_weekly_screening_stats). Post-#39 parse-once guards now at L446/L575. redcap_api.md flags historical positions + documents that the raw-guard STYLE persists on sibling criteria fields (L440-450 / L568-580) as the AC-3.9 sweep target.
 
 ### Surprises & Discoveries
-- (none yet)
+- okf-bundle skill Step-7 link-validation script has a latent bug: `rg -no` emits `path:line:` prefixes, so `while read p` receives the whole prefix and `[ -f "docs/okf${p}" ]` can never succeed — EVERY absolute-style mdlink (`](/path.md)`) is falsely reported BROKEN. Workaround: use same-dir relative links (`name.md`) and cross-dir relative links (`../modules/index.md`) — none match the `](/` regex, verbatim script output is zero, and all links resolve (verified per-file). Any future doc that adds an absolute-style link will re-trigger the false positive.
+- macOS BSD grep has no `-P` (PCRE): the spec's P5/P9 probes (`grep -iP`, `grep -oP`) fail on this machine. Equivalent `-E` regex + `sed`/`rg -P` extraction produce identical semantics; results reported from those.
+- R CMD build completes in seconds in this env (no renv restore needed for tarball build), so P7 was fully verified (tarball grep empty) rather than falling back to the line-presence check.
 
 ### Idempotence & Recovery
 - Safe retry: re-run okf-bundle skill generation; files idempotent.

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -1,0 +1,22 @@
+---
+okf_version: 0.1
+---
+
+# abmdash OKF Knowledge Bundle
+
+Curated knowledge map of the `abmdash` R package (ABM project dashboard).
+Agents: read this index first, then the concept docs, before falling back to
+raw source under `R/`.
+
+## Subdirectories
+
+- [modules](modules/index.md) - R/ module concept docs (9 modules, one per source file)
+- [services](services/index.md) - deployable service docs (Docker + CI dashboard build)
+
+## Conventions
+
+- Concept boundaries == `R/` file boundaries; one concept doc per source file.
+- `pure: true` frontmatter marks pure-core modules; `false` marks effectful API shells.
+- Cross-links use bundle-relative absolute paths (`/modules/redcap_api.md`).
+- Source ground truth: `DESCRIPTION`, `NAMESPACE`, `R/*.R`, `Dockerfile`,
+  `.github/workflows/build-dashboard.yml`, `build-dashboard.sh`.

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -17,6 +17,6 @@ raw source under `R/`.
 
 - Concept boundaries == `R/` file boundaries; one concept doc per source file.
 - `pure: true` frontmatter marks pure-core modules; `false` marks effectful API shells.
-- Cross-links use bundle-relative absolute paths (`/modules/redcap_api.md`).
+- Cross-links use relative paths — same-dir links as `name.md`, cross-dir links as `../modules/name.md`. Bundle-absolute style (`/modules/...`) is avoided because the okf-bundle skill Step-7 link validator falsely reports such links as broken (see log.md).
 - Source ground truth: `DESCRIPTION`, `NAMESPACE`, `R/*.R`, `Dockerfile`,
   `.github/workflows/build-dashboard.yml`, `build-dashboard.sh`.

--- a/docs/okf/log.md
+++ b/docs/okf/log.md
@@ -1,0 +1,7 @@
+# Change Log
+
+## 2026-08-13
+- Bundle generated. 10 concept docs created (9 modules + 1 service), 0 updated, 1 skipped.
+- Skipped: `week12_tracking.R` (1 exported function) — dependency mention only, per okf-bundle boundary rule (<2 public functions).
+- 33 NAMESPACE exports cross-referenced across `# Interface` sections (NAMESPACE contains 33 `export()` lines; no invented exports).
+- Conformance: PASS

--- a/docs/okf/modules/abs_login.md
+++ b/docs/okf/modules/abs_login.md
@@ -1,0 +1,54 @@
+---
+type: Module
+title: ABS Portal Login + CSV Download
+description: Effectful Livewire-authenticated httr2 session against the ABS admin portal, plus test-data CSV download.
+resource: R/abs_login.R
+tags: [r, abs, livewire, httr2, auth]
+timestamp: 2026-08-13
+pure: false
+---
+
+# Responsibility
+
+What this module does: authenticates to the ABS (Attention Bias Study) admin
+portal at `https://abs.la.utexas.edu` via its Livewire update endpoint, returns
+a cookie-preserving `httr2` request, and downloads the complete test-data CSV
+through the Livewire `downloadCompleteCsv` action.
+
+What it does NOT do: it does not compute compliance (that is
+[trad_compliance](trad_compliance.md)), does not touch REDCap or Google APIs,
+and never stores credentials.
+
+# Interface
+
+All 5 exported functions (NAMESPACE):
+
+- `abs_login(base_url = "https://abs.la.utexas.edu", login_path = "/admin/login", check_connection = TRUE)` — returns authenticated `httr2` request (session cookies preserved in a temp cookie jar)
+- `test_abs_connection(base_url = "https://abs.la.utexas.edu", verbose = TRUE)` — logical reachability probe
+- `verify_abs_login(session, test_path = "/admin")` — logical check that the session still authenticates
+- `download_abs_csv(session, tests_path = "/admin/tests", save_path = NULL, ...)` — data.frame of the full test-data CSV
+- `preview_abs_csv(session, n = 6)` — prints head, invisibly returns the full data.frame
+
+Internal helpers: `extract_livewire_snapshot(html)`, `extract_csrf_token(html)`.
+
+# Dependencies
+
+- [trad_compliance](trad_compliance.md) — consumes `abs_login()` + `download_abs_csv()`
+- R packages: `httr2` (HTTP + cookie jar), `jsonlite` (Livewire payload/response), `utils` (CSV)
+
+# Invariants
+
+- `ABS_USERNAME` and `ABS_PASSWORD` env vars are required; both are `trimws()`ed and stripped of surrounding quotes (secrets-manager artifact hygiene).
+- SSL verification disabled (`ssl_verifypeer = 0`, `ssl_verifyhost = 0`) and `http_version = 2` forced — the ABS server sends malformed HTTP/2 headers.
+- Login success is detected by the presence of a Livewire `effects.redirect`; failure raises a diagnostic error (HTTP status, component effects, HTML text) for the dashboard.
+- `download_abs_csv()` raises "Not authenticated" when the tests page redirects to the login page.
+
+# Examples
+
+```r
+session <- abs_login()
+if (verify_abs_login(session)) {
+  data <- download_abs_csv(session)
+}
+preview_abs_csv(session, n = 6)
+```

--- a/docs/okf/modules/compliance_summary.md
+++ b/docs/okf/modules/compliance_summary.md
@@ -1,0 +1,46 @@
+---
+type: Module
+title: Participant Compliance Summary
+description: Pure per-participant view over the compliance report — one row per participant, current week, totals, and sessions behind.
+resource: R/compliance_summary.R
+tags: [r, compliance, pure, dashboard]
+timestamp: 2026-08-13
+pure: true
+---
+
+# Responsibility
+
+What this module does: collapses the long-format compliance report from
+[compliance_tracking](compliance_tracking.md) into one row per participant
+(current week, weeks from start, total completed sessions, expected sessions,
+sessions behind, start date), sorted most-behind-first, and a convenience
+filter for behind participants.
+
+What it does NOT do: it performs no network I/O itself (it delegates sheet
+reading to `get_compliance_report()`), does not touch REDCap or the ABS portal,
+and does not render.
+
+# Interface
+
+Both exported functions (NAMESPACE):
+
+- `get_participant_summary(sheet_url, sheet_name = NULL, exclude_ids = c("123456789", "12345678"), sessions_per_week = 4)` — data.frame, one row per participant, sorted by `sessions_behind` descending
+- `get_behind_participants(sheet_url, sheet_name = NULL, min_sessions_behind = 1)` — subset of the summary where `sessions_behind >= min_sessions_behind` (invisible return)
+
+# Dependencies
+
+- [compliance_tracking](compliance_tracking.md) — consumes `get_compliance_report()`
+- R packages: base R only (no imports beyond what compliance_tracking pulls in)
+
+# Invariants
+
+- Expected sessions are capped at 16 (4 weeks x 4/week); `current_week` is capped at 4.
+- `sessions_behind` negative means ahead of schedule; sorting is descending by `sessions_behind` (most behind first).
+- `start_date` is back-derived from the latest week's start: `start - ((current_week - 1) * 7 days)`.
+
+# Examples
+
+```r
+summary <- get_participant_summary(sheet_url)
+behind <- get_behind_participants(sheet_url, min_sessions_behind = 2)
+```

--- a/docs/okf/modules/compliance_tracking.md
+++ b/docs/okf/modules/compliance_tracking.md
@@ -1,0 +1,49 @@
+---
+type: Module
+title: GABM Compliance Tracking
+description: Computes expected-vs-actual weekly sessions from Google Sheets gameplay events for GABM participants.
+resource: R/compliance_tracking.R
+tags: [r, compliance, sheets, dashboard]
+timestamp: 2026-08-13
+pure: false
+---
+
+# Responsibility
+
+What this module does: reads gameplay events from a Google Sheet via
+[gsheet_api](gsheet_api.md), filters to completed sessions (180 turns), derives
+week-1 start dates, builds week 1-4 study windows, and flags late participants
+(`late` = `sess_cnt + 1 < expect_cnt`). Also surfaces 178-179-turn sessions as
+suspiciously short.
+
+What it does NOT do: it does not handle traditional ABM data from the ABS
+portal (see [trad_compliance](trad_compliance.md)) and does not collapse to
+per-participant rows (see [compliance_summary](compliance_summary.md)).
+
+# Interface
+
+Both exported functions (NAMESPACE):
+
+- `get_compliance_report(sheet_url, sheet_name = NULL, exclude_ids = c("123456789", "12345678"), sessions_per_week = 4)` — list with `compliance` (active participant-weeks) and `short_sessions` (178-179 turns)
+- `get_late_participants(sheet_url, sheet_name = NULL)` — data.frame of rows flagged `late` (invisible return)
+
+# Dependencies
+
+- [gsheet_api](gsheet_api.md) — consumes `read_google_sheet()`
+- [compliance_summary](compliance_summary.md) — consumer of `get_compliance_report()`
+- R packages: base R (`aggregate`, `merge`, `difftime`)
+
+# Invariants
+
+- Sheet columns are mapped by display name: `Referral ID`, `Date of Event UTC`, `Event Type`, `Week #`, `Session #`, `Turns Completed`; "N/A" string values are converted to NA BEFORE `as.numeric()`.
+- A session counts only when `Turns Completed == 180`; `sess_cnt` is the max session number per id+week; missing counts default to 0.
+- Expected rate: `sessions_per_week / 7` per day (default 4/week); compliance window is `0 < time_from_start < 5` weeks.
+- Excluded: default test IDs, any id containing "test" (case-insensitive), non-Gameplay events.
+
+# Examples
+
+```r
+result <- get_compliance_report(sheet_url)
+head(result$compliance)
+late <- get_late_participants(sheet_url)
+```

--- a/docs/okf/modules/demographics.md
+++ b/docs/okf/modules/demographics.md
@@ -1,0 +1,49 @@
+---
+type: Module
+title: Demographics Summary
+description: Summarizes REDCap demographic reports (race, ethnicity, sex, age) for enrolled participants.
+resource: R/demographics.R
+tags: [r, demographics, redcap, pure]
+timestamp: 2026-08-13
+pure: true
+---
+
+# Responsibility
+
+What this module does: pulls a REDCap demographic report (default report 13349)
+via [redcap_api](redcap_api.md), optionally filters to enrolled IDs, recodes
+race/ethnicity/sex from REDCap checkbox/coded fields, computes age from
+`interview_age`, and builds summary tables for dashboard display.
+
+What it does NOT do: it does not compute compliance, does not handle
+enrollment statistics (see `get_enrollment_stats()` in
+[redcap_api](redcap_api.md)), and does not render. `summarize_demographics()`
+is a pure transform; the only effectful boundary is the `get_redcap_report()`
+fetch inside `get_demographic_summary()`.
+
+# Interface
+
+Both exported functions (NAMESPACE):
+
+- `get_demographic_summary(report_id = "13349", enrolled_ids = NULL)` — data.frame with `record_id`, `race`, `ethnicity`, `sex`, `age`
+- `summarize_demographics(demo_data)` — list with `overall`, `age_groups`, `sex`, `race`, `ethnicity` summary frames
+
+# Dependencies
+
+- [redcap_api](redcap_api.md) — consumes `get_redcap_report()`
+- R packages: base R only
+
+# Invariants
+
+- REDCap event names are fixed: `eligibility_screen_arm_1` (race/sex/age) and `week_0_eligibility_arm_1` (ethnicity).
+- Race recoding from checkbox fields `raceid___1`..`raceid___7` ("American Indian", "Asian", "Black", "Hawaiian", "White", "More than one race", "Unknown").
+- Unknown values fall back to `"Unknown"` for categorical fields; missing age stays NA; `summarize_demographics()` drops "Unknown" and NA before counting.
+- Age groups: `cut(breaks = c(0,18,25,35,45,55,100), right = FALSE)`.
+
+# Examples
+
+```r
+demo <- get_demographic_summary()
+summaries <- summarize_demographics(demo)
+summaries$race
+```

--- a/docs/okf/modules/gcal_api.md
+++ b/docs/okf/modules/gcal_api.md
@@ -1,0 +1,52 @@
+---
+type: Module
+title: Google Calendar Reader
+description: Effectful service-account OAuth2 read of Google Calendar events across one or many calendars.
+resource: R/gcal_api.R
+tags: [r, google, calendar, oauth2, httr2]
+timestamp: 2026-08-13
+pure: false
+---
+
+# Responsibility
+
+What this module does: lists and fetches Google Calendar events using the same
+service-account OAuth2 flow as [gsheet_api](gsheet_api.md) (calendar.readonly
+scope), including a multi-calendar merge that tolerates per-calendar failures.
+
+What it does NOT do: it is read-only — no event creation/updates; it does not
+read Sheets and does not compute compliance.
+
+# Interface
+
+All 3 exported functions (NAMESPACE):
+
+- `get_calendar_events(calendar_id = "primary", time_min = NULL, time_max = NULL, max_results = 10)` — list of event objects (raw Calendar API JSON)
+- `list_calendars()` — calendars the service account can see (`users/me/calendarList`)
+- `get_combined_calendar_events(calendar_ids, time_min = NULL, time_max = NULL, max_results = 100)` — list with `$items` merged from all calendars; one failing calendar degrades to a message, others still return
+
+Internal helper: `get_google_access_token(service_account)`.
+
+# Dependencies
+
+- [gsheet_api](gsheet_api.md) — sibling sharing the JWT service-account pattern
+- R packages: `httr2`, `jsonlite`, `jose`, `openssl`, `utils`
+- Environment: `GOOGLE_SERVICE_ACCOUNT_JSON`
+
+# Invariants
+
+- Same defensive JSON parsing and `\\n` private-key unescaping as `gsheet_api`.
+- `calendar_id` is `utils::URLencode`d (`reserved = TRUE`) before path interpolation.
+- Tokens are requested per call with a 1-hour `exp` claim (no caching).
+
+# Examples
+
+```r
+events <- get_calendar_events(
+  time_min = paste0(Sys.Date(), "T00:00:00Z"),
+  time_max = paste0(Sys.Date(), "T23:59:59Z")
+)
+combined <- get_combined_calendar_events(
+  c("a@group.calendar.google.com", "b@group.calendar.google.com")
+)
+```

--- a/docs/okf/modules/gsheet_api.md
+++ b/docs/okf/modules/gsheet_api.md
@@ -1,0 +1,55 @@
+---
+type: Module
+title: Google Sheets Reader
+description: Effectful service-account OAuth2 read of Google Sheets, plus recent-response/issue monitoring helpers.
+resource: R/gsheet_api.R
+tags: [r, google, sheets, oauth2, httr2]
+timestamp: 2026-08-13
+pure: false
+---
+
+# Responsibility
+
+What this module does: reads Google Sheets data with a service-account OAuth2
+access token (JWT-signed via `jose`/`openssl`), converting the Sheets `values`
+payload into a data.frame, and provides monitoring conveniences for response
+forms and the participant-issues sheet.
+
+What it does NOT do: it is read-only (`spreadsheets.readonly` scope) — no
+writes; it does not touch Google Calendar (see [gcal_api](gcal_api.md)) and
+does not compute compliance (see [compliance_tracking](compliance_tracking.md)).
+
+# Interface
+
+All 4 exported functions (NAMESPACE):
+
+- `read_google_sheet(sheet_url, sheet_name = NULL, range = NULL)` — data.frame; first row becomes column names, shorter rows padded with NA
+- `print_sheet_head(sheet_url, n = 6, sheet_name = NULL)` — prints head, invisibly returns full data.frame
+- `check_recent_responses(sheet_url, days_back = 14, timestamp_col = 1, sheet_name = NULL)` — list with `has_recent`, `recent_count`, `recent_data`, `all_data`, `cutoff_date`
+- `check_participant_issues(days_back = 14, verbose = TRUE)` — recent-issues monitor against the hard-coded participant-issues sheet URL
+
+Internal helpers: `extract_sheet_id(url)` (regex `/d/([a-zA-Z0-9_-]+)`), `get_google_sheets_access_token()` (JWT + token POST).
+
+# Dependencies
+
+- [compliance_tracking](compliance_tracking.md) — consumes `read_google_sheet()`
+- [gcal_api](gcal_api.md) — sibling: same service-account pattern, calendar scope
+- R packages: `httr2`, `jsonlite`, `jose` (JWT claim + sign), `openssl` (key read), `utils`
+- Environment: `GOOGLE_SERVICE_ACCOUNT_JSON` (service-account JSON, possibly escaped in `.Renviron`)
+
+# Invariants
+
+- The service-account JSON is parsed defensively: outer quotes stripped, `\\"` unescaped.
+- Private-key newlines arrive escaped (`\\n`) and are unescaped before `openssl::read_key`.
+- Timestamp parsing tries three formats in order: `%m/%d/%Y %H:%M:%S`, `%Y-%m-%d %H:%M:%S`, then POSIX auto-detect.
+- Empty sheets return `data.frame()` (with a warning), header-only sheets return a 0-row frame with the header columns.
+
+# Examples
+
+```r
+data <- read_google_sheet(
+  "https://docs.google.com/spreadsheets/d/SHEET_ID/edit",
+  sheet_name = "Sheet1"
+)
+issues <- check_participant_issues(days_back = 7)
+```

--- a/docs/okf/modules/index.md
+++ b/docs/okf/modules/index.md
@@ -1,0 +1,16 @@
+# Modules
+
+One concept doc per `R/` source file with >1 public function. `week12_tracking.R`
+(1 export) is covered as a dependency mention inside [run_initial_function](run_initial_function.md).
+
+## Concepts
+
+- [redcap_api](redcap_api.md) - effectful shell over the REDCap API (9 exports, 2 internal helpers)
+- [abs_login](abs_login.md) - Livewire session auth + CSV download for the ABS admin portal (5 exports, 2 internal)
+- [gsheet_api](gsheet_api.md) - read Google Sheets via service-account OAuth2 (4 exports, 2 internal)
+- [gcal_api](gcal_api.md) - read Google Calendar events via service-account OAuth2 (3 exports, 1 internal)
+- [run_initial_function](run_initial_function.md) - bootstrap/misc: entry stub, dashboard encryption, clock, enrollment targets (4 exports)
+- [compliance_summary](compliance_summary.md) - pure per-participant compliance view (2 exports)
+- [compliance_tracking](compliance_tracking.md) - expected-vs-actual session compliance from Google Sheets (2 exports)
+- [trad_compliance](trad_compliance.md) - traditional ABM compliance from the ABS portal (1 export, 1 internal)
+- [demographics](demographics.md) - summarize REDCap demographic reports (2 exports)

--- a/docs/okf/modules/redcap_api.md
+++ b/docs/okf/modules/redcap_api.md
@@ -1,0 +1,65 @@
+---
+type: Module
+title: REDCap API Shell
+description: Effectful httr2 shell over the REDCap API — records, metadata, reports, logs, and derived eligibility/enrollment stats.
+resource: R/redcap_api.R
+tags: [r, redcap, api, httr2, invariant]
+timestamp: 2026-08-13
+pure: false
+---
+
+# Responsibility
+
+What this module does: POSTs REDCap API calls to
+`https://redcap.prc.utexas.edu/redcap/api/` using the token from the
+`REDCAP_API_TOKEN` environment variable, and derives screening/eligibility,
+weekly-screening, and enrollment statistics from REDCap reports 14081 and 13387.
+
+What it does NOT do: it does not persist data, does not render anything, does
+not touch Google Sheets/Calendar or the ABS portal, and does not own the
+compliance calculations (those live in [compliance_tracking](compliance_tracking.md)
+and [trad_compliance](trad_compliance.md)).
+
+# Interface
+
+All 9 exported functions (NAMESPACE):
+
+- `call_redcap_api(content = "record", format = "json", ...)` — raw API call; parses JSON to list, CSV to data.frame
+- `get_redcap_records(fields = NULL, forms = NULL, records = NULL, events = NULL, format = "json")` — records with field/form/record/event filters
+- `get_redcap_metadata(format = "json")` — data dictionary
+- `get_survey_completions(surveys = NULL, records = NULL, format = "json")` — long-format `record_id`/`survey_instrument`/`survey_timestamp`/`survey_complete` from `_timestamp`/`_complete` fields
+- `get_redcap_logs(records = NULL, begin_time = NULL, end_time = NULL)` — logging data
+- `get_redcap_report(report_id, format = "json", date_begin = NULL, date_end = NULL)` — report export by ID
+- `get_eligible_participants()` — eligibility filter over report 14081 (past 30 days, `phq8score >= 17`, commute/austin/phone/computer/bpd/druguse/medchng criteria)
+- `get_weekly_screening_stats()` — past-7-day screening totals, eligible and Hispanic counts from report 14081
+- `get_enrollment_stats()` — enrollment counts from report 13387 keyed on a GUID field
+
+Internal helpers: `get_redcap_token()` (env read), `` `%||%` `` (null coalescing).
+
+# Dependencies
+
+- [demographics](demographics.md) — consumes `get_redcap_report()` (report 13349)
+- [week12_tracking](run_initial_function.md) — consumes `get_redcap_logs()` for follow-up scheduling (dependency mention; 1-export module, no own doc)
+- R packages: `httr2` (HTTP), `jsonlite`, `utils` (CSV), plus `as.Date`/`aggregate` from base R
+
+# Invariants
+
+- REDCap API returns empty string `""` (NOT `NA`) for unset fields; `as.numeric("")` returns `NA`.
+- Parse numeric REDCap fields ONCE with `suppressWarnings(as.numeric(...))` and guard on the PARSED value — never `!is.na(raw) & as.numeric(raw) >= N`. An NA leaking into a logical row index inserts an all-NA row, and `data.frame()` then raises "row names contain missing values".
+- Use `sapply(..., USE.NAMES = FALSE)` so value vectors never become row names (see the `r01es_name` -> `first_name` extraction).
+- **FLAG (L441/L563):** the phq8score raw-string guard (`!is.na(phq8score) & as.numeric(phq8score) >= 17`) that caused bug #38 sat at `redcap_api.R` L441 (`get_eligible_participants`) and L563 (`get_weekly_screening_stats`). Fix #39 (commit 90ef649) replaced both with parse-once guards (now at L446 / L575). The raw-guard STYLE (`!is.na(x) & x == "1"`) persists on sibling eligibility fields at L440-450 / L568-580 — benign for character equality, but flagged as the remaining sweep target for wave-3a / AC-3.9.
+- All wrapper functions return zero-row data.frames / error-carried frames rather than raising on empty reports.
+
+# Examples
+
+```r
+# Raw records
+recs <- call_redcap_api("record", format = "csv")
+
+# Eligibility over the past 30 days (report 14081)
+eligible <- get_eligible_participants()
+
+# Enrollment stats (report 13387)
+enr <- get_enrollment_stats()
+enr$total_enrolled
+```

--- a/docs/okf/modules/run_initial_function.md
+++ b/docs/okf/modules/run_initial_function.md
@@ -1,0 +1,55 @@
+---
+type: Module
+title: Bootstrap and Misc Helpers
+description: Package entry stub, dashboard-encryption hook, Central-Time clock, enrollment-targets CSV reader, and home of the week12_tracking dependency mention.
+resource: R/run_initial_function.R
+tags: [r, bootstrap, dashboard, env]
+timestamp: 2026-08-13
+pure: false
+---
+
+# Responsibility
+
+What this module does: hosts the package's small bootstrap/utility functions —
+the `run_initial_function(n)` entry stub, the `encrypt_dashboard()` staticrypt
+hook, a Central-Time clock for the dashboard header, and the enrollment-targets
+CSV reader. It is also the anchor doc for `week12_tracking.R` (a 1-export module,
+below the okf-bundle concept threshold, so it is documented as a dependency here).
+
+What it does NOT do: it is not the data engine — no REDCap/ABS/Google calls
+beyond the CSV read; no compliance logic.
+
+# Interface
+
+Exported functions (NAMESPACE):
+
+- `run_initial_function(n)` — returns `n + n` (entry stub)
+- `encrypt_dashboard()` — no-op unless `STATICRYPT_PASSWORD` is set; resolves the docs dir as `/app/docs` (Docker) → `../../docs` → `docs`
+- `get_central_time()` — formatted Central Time string (`%Y-%m-%d %I:%M %p %Z`, tz `America/Chicago`)
+- `get_enrollment_targets()` — data.frame from `enrollment_targets.csv`, probing 6 candidate paths (system.file extdata, `inst/extdata/`, `data/`, relative variants)
+
+Related export defined in the sibling 1-export module [week12_tracking](run_initial_function.md) (dependency):
+
+- `get_upcoming_followups(days_ahead = 14)` — Week 12/16/28 follow-up scheduling from REDCap logs (source: `R/week12_tracking.R`)
+
+# Dependencies
+
+- [week12_tracking](run_initial_function.md) — `get_upcoming_followups()` (dependency mention; consumes `get_redcap_logs()` from [redcap_api](redcap_api.md))
+- [redcap_api](redcap_api.md) — transitively, via `get_upcoming_followups()`
+- Files: `inst/extdata/enrollment_targets.csv`, `data/enrollment_targets.csv`
+- R packages: `utils` (read.csv)
+
+# Invariants
+
+- `encrypt_dashboard()` must never fail the build when `STATICRYPT_PASSWORD` is unset — it returns invisibly.
+- `get_enrollment_targets()` raises if none of the 6 candidate paths exist.
+- `get_upcoming_followups()` skips withdrawn participants and already-completed follow-up types.
+
+# Examples
+
+```r
+run_initial_function(5)          # 10
+get_central_time()               # "2026-08-13 10:30 AM CDT"
+targets <- get_enrollment_targets()
+encrypt_dashboard()              # no-op without STATICRYPT_PASSWORD
+```

--- a/docs/okf/modules/run_initial_function.md
+++ b/docs/okf/modules/run_initial_function.md
@@ -28,13 +28,13 @@ Exported functions (NAMESPACE):
 - `get_central_time()` — formatted Central Time string (`%Y-%m-%d %I:%M %p %Z`, tz `America/Chicago`)
 - `get_enrollment_targets()` — data.frame from `enrollment_targets.csv`, probing 6 candidate paths (system.file extdata, `inst/extdata/`, `data/`, relative variants)
 
-Related export defined in the sibling 1-export module [week12_tracking](run_initial_function.md) (dependency):
+Related export defined in the sibling 1-export module week12_tracking (dependency):
 
 - `get_upcoming_followups(days_ahead = 14)` — Week 12/16/28 follow-up scheduling from REDCap logs (source: `R/week12_tracking.R`)
 
 # Dependencies
 
-- [week12_tracking](run_initial_function.md) — `get_upcoming_followups()` (dependency mention; consumes `get_redcap_logs()` from [redcap_api](redcap_api.md))
+- week12_tracking — `get_upcoming_followups()` (dependency mention; consumes `get_redcap_logs()` from [redcap_api](redcap_api.md))
 - [redcap_api](redcap_api.md) — transitively, via `get_upcoming_followups()`
 - Files: `inst/extdata/enrollment_targets.csv`, `data/enrollment_targets.csv`
 - R packages: `utils` (read.csv)

--- a/docs/okf/modules/trad_compliance.md
+++ b/docs/okf/modules/trad_compliance.md
@@ -1,0 +1,49 @@
+---
+type: Module
+title: Traditional ABM Compliance
+description: Computes traditional-ABM compliance from the ABS portal CSV, mirroring the GABM summary output shape.
+resource: R/trad_compliance.R
+tags: [r, compliance, abs, dashboard]
+timestamp: 2026-08-13
+pure: false
+---
+
+# Responsibility
+
+What this module does: logs into the ABS portal via [abs_login](abs_login.md),
+downloads the session CSV, and computes a per-participant compliance summary
+(current week, weeks from start, total sessions, expected sessions, sessions
+behind, start date, On Track / Behind-by-N status) that mirrors the output
+shape of `get_participant_summary()` from [compliance_summary](compliance_summary.md).
+
+What it does NOT do: it does not read Google Sheets, does not touch REDCap,
+and does not handle GABM gameplay events (see
+[compliance_tracking](compliance_tracking.md)).
+
+# Interface
+
+Exported functions (NAMESPACE):
+
+- `get_trad_compliance_summary(base_url = "https://abs.la.utexas.edu", csv_path = "/admin/test/download-csv-all", exclude_pattern = "test", sessions_per_week = 4, active_window_weeks = 5, verbose = FALSE)` — data.frame, one row per active participant, most-behind first
+
+Internal helper: `process_trad_compliance_data(trad_data, ...)` — pure transform of the raw CSV (testable without the portal).
+
+# Dependencies
+
+- [abs_login](abs_login.md) — consumes `abs_login()` and `download_abs_csv()`
+- R packages: base R only
+
+# Invariants
+
+- Requires columns `subject_id`, `session`, `start_time`; missing columns raise `stop()` before any computation.
+- `start_time` parsed with `as.POSIXct(..., tz = "UTC")`; test ids filtered by `exclude_pattern` (default `"test"`, case-insensitive).
+- Active window: `weeks_from_start <= active_window_weeks` (default 5); expected sessions capped at 16.
+- Status: `"On Track"` when `sessions_behind <= 0`, else `"Behind by N"`.
+- The empty result is returned as a 0-row frame with the full column schema (early returns never change shape).
+
+# Examples
+
+```r
+summary <- get_trad_compliance_summary()
+print(summary[, c("id", "current_week", "status")])
+```

--- a/docs/okf/services/deploy-pipeline.md
+++ b/docs/okf/services/deploy-pipeline.md
@@ -1,0 +1,51 @@
+---
+type: Service
+title: Dashboard Deploy Pipeline
+description: Dockerfile 2-stage image + GitHub Actions daily dashboard build (quarto render + staticrypt) + local build script, including the documented docs/ clobber risk.
+resource: Dockerfile, .github/workflows/build-dashboard.yml, build-dashboard.sh
+tags: [docker, github-actions, quarto, staticrypt, deploy]
+timestamp: 2026-08-13
+pure: false
+---
+
+# Responsibility
+
+What this service does: builds the R + Quarto dashboard into a static site in
+`docs/` (optionally password-encrypted with staticrypt), every day at 06:00 UTC
+via GitHub Actions, on push to `main`, or manually. It also supports the same
+build locally via `build-dashboard.sh`.
+
+What it does NOT do: it does not run the tests, does not deploy elsewhere
+(GitHub Pages is not used — `docs/` is committed directly), and does not
+modify `docs/okf/` (the knowledge bundle lives in `docs/` too — see the
+clobber risk below).
+
+# Interface
+
+Entry points:
+
+- `Dockerfile` — the image consumed by both CI and local runs
+- `.github/workflows/build-dashboard.yml` — CI orchestration
+- `build-dashboard.sh` — local orchestration (Docker build + run)
+
+# Dependencies
+
+- Modules: all `R/` modules via [modules index](../modules/index.md) — the dashboard renders their outputs
+- Docker base: `rocker/r-ver:4.5.1`
+- Tooling: Node.js 18 + `staticrypt` (global npm), Quarto CLI v1.4.550 (`/usr/local/bin/quarto`)
+- Secrets: `STATICRYPT_PASSWORD`, `REDCAP_API_TOKEN`, `GOOGLE_SERVICE_ACCOUNT_JSON`, `ABS_USERNAME`, `ABS_PASSWORD`
+
+# Invariants
+
+- **Dockerfile is 2-stage.** Stage 1 (`base`, `rocker/r-ver:4.5.1`) installs system deps, copies `renv.lock` + `renv/activate.R`, and runs `renv::restore()`. Stage 2 (runtime, same base) additionally installs Node 18 + staticrypt and the Quarto CLI, then copies the renv library from stage 1 (`COPY --from=base /project .`) and the app files. The env vars `REDCAP_API_TOKEN`/`GOOGLE_SERVICE_ACCOUNT_JSON`/`STATICRYPT_PASSWORD` are defaulted empty in the image.
+- **CI is 2 jobs.** `build-image` (buildx → pushes `ghcr.io/moodlab/abmdash` with branch/sha/latest tags, GHA cache) and `build-dashboard` (`needs: build-image`; checks out the repo, `docker run`s the pushed image to render `inst/dashboard/index.qmd` via quarto into the mounted `docs/` volume, staticrypt-encrypts `*.html`, then commits `git add -f docs/` with a 🤖 message and pushes). Artifacts uploaded via `actions/upload-artifact`.
+- **Triggers:** `schedule` cron `'0 6 * * *'` (daily 6 AM UTC) + `workflow_dispatch` + `push` to `main`. `concurrency` group `dashboard-build`, `cancel-in-progress: false`.
+- **The docker-run write surface is narrow:** the R snippet writes only `index.html` and `site_libs/` into `/project/docs` (workflow L108-111); the staticrypt loop touches only `*.html` in the docs root (L114-134). So `docs/okf/` is left byte-identical, and the `git add -f docs/` commit step produces no diff for it.
+- **LATENT CLOBBER RISK (documented only, NOT fixed):** `build-dashboard.sh` L53 runs `rm -rf docs` before `mkdir -p docs`. Executed locally, this DELETES `docs/okf/` (and `docs/evidence/`) before the Docker render rebuilds the dir — the knowledge bundle would be destroyed on a local run. The CI workflow does NOT do this (it mounts the repo's existing `docs/` and writes over it), so CI is safe. Do not run `build-dashboard.sh` locally without first backing up `docs/okf/`; the fix (e.g. `rm -rf docs/*` or removing the line) is intentionally out of scope for the docs/okf AC.
+
+# Examples
+
+```bash
+# CI (safe): push to main, workflow_dispatch, or cron 06:00 UTC
+# Local (DANGEROUS for docs/okf): ./build-dashboard.sh   # rm -rf docs at L53
+```

--- a/docs/okf/services/index.md
+++ b/docs/okf/services/index.md
@@ -1,0 +1,5 @@
+# Services
+
+## Concepts
+
+- [deploy-pipeline](deploy-pipeline.md) - Dockerfile 2-stage image + GitHub Actions daily dashboard build + local build script


### PR DESCRIPTION
## Summary

Adds the OKF knowledge bundle at `docs/okf/` so agents can navigate the abmdash codebase without re-reading raw source. Also fixes `.gitignore` (`docs/` → `docs/*` + `!docs/okf/`) so the bundle is actually trackable — git cannot re-include under an excluded parent dir, so the old pattern silently ignored it.

**Bundle contents (14 files):** `index.md`, `log.md`, `modules/index.md` + 9 module concept docs (redcap_api, abs_login, gsheet_api, gcal_api, run_initial_function, compliance_summary, compliance_tracking, trad_compliance, demographics), `services/index.md` + `services/deploy-pipeline.md`. Every concept doc has YAML frontmatter with `type:` + all 5 body sections (`# Responsibility`, `# Interface`, `# Dependencies`, `# Invariants`, `# Examples`). `week12_tracking.R` (1 export) is a dependency mention in the run_initial_function doc per the okf-bundle boundary rule.

**Highlights:**
- `redcap_api.md` `# Invariants` documents the `""`-not-`NA` parse-guard invariant (parse once with `suppressWarnings(as.numeric())`, guard the PARSED value, `USE.NAMES=FALSE` in sapply) and flags the remaining raw-guard instances — verified via `git show 90ef649^` that the pre-fix-#39 phq8score raw-guard sat at exactly **L441** (get_eligible_participants) and **L563** (get_weekly_screening_stats); post-fix parse-once guards now live at L446/L575, and the raw-guard STYLE persists on sibling eligibility fields (L440-450 / L568-580) as the AC-3.9 sweep target.
- `deploy-pipeline.md` documents the Dockerfile 2-stage build (rocker/r-ver:4.5.1 + Node18/staticrypt + quarto), the 2-job CI workflow (build-image → build-dashboard; cron 06:00 UTC + push main + workflow_dispatch), and the **LATENT CLOBBER RISK**: `build-dashboard.sh` L53 `rm -rf docs` destroys `docs/okf/` on local runs — documented, NOT fixed (out of scope).
- All NAMESPACE exports cross-referenced in `# Interface` sections; no invented exports.

## Issue

Closes #40

## ACs implemented

- [x] docs/okf/ bundle: index.md + log.md + 9 module docs + deploy-pipeline service doc, git-tracked (14 files)
- [x] All concept docs conform to okf-bundle skill (frontmatter type: + 5 body sections), zero broken cross-links
- [x] .gitignore uses `docs/*` + `!docs/okf/` — exception works (check-ignore exits non-zero; probe file visible in git status without -f)
- [x] .Rbuildignore verified already-satisfied (`^docs/` line 6; tarball excludes docs/okf) — NOT edited
- [x] build-dashboard.yml verified read-only-safe (`git diff --exit-code` clean; no destructive cmd on docs/okf)
- [x] redcap_api.md documents the `""`-not-NA parse-guard invariant AND flags L441/L563 (pre-fix raw-guard positions, verified from history)
- [x] All NAMESPACE exports cross-referenced in `# Interface` sections (33 actual exports — see deviations)

## Test plan

All probes P1–P9 from AC-1.1.md green (full output below). `verification: code + manual` — probe commands are the fixture; no tests/testthat/ change (docs/config AC). No `docs/evidence/` committed (docs/ is the deployed dashboard output; evidence there would publish publicly).

## Probe output (P1–P9)

```
=== P1: bundle tracked + log conformance ===
index.md exists ✓
tracked files: 14 (>=1)
log.md conformance PASS entry ✓

=== P2: concept docs >=10, all >200 bytes ===
concept docs (non-index/log): 10 (>=10)
find -size -200c: (empty = OK)

=== P3: conformance (frontmatter + type + 5 sections) ===
(zero output = OK)

=== P4: link validation (skill Step-7, verbatim) ===
(zero output = OK)

=== P5: redcap invariant + L441/L563 flags ===
invariant pattern ✓  (as.numeric("") / NA leak / parse-guard / suppressWarnings)
L441/L563+phq8score flags ✓

=== P6 (critical): gitignore exception works ===
git check-ignore docs/okf/modules/redcap_api.md → exit=1 (non-zero = not ignored)
probe file: ?? docs/okf/modules/_probe.md   (visible in git status without -f)

=== P7: Rbuildignore ^docs/ + tarball exclusion ===
Rbuildignore ^docs/ ✓ (line 6, UNCHANGED)
R CMD build . → tarball abmdash_0.0.11.tar.gz built; tar tf | grep docs/okf → EMPTY ✓
(tarball removed after check)

=== P8: workflow unmodified + no docs/okf clobber ===
git diff --exit-code .github/workflows/build-dashboard.yml → exit=0 (UNMODIFIED)
no destructive cmd on docs/okf ✓ (only benign `docker run --rm`, `rmdir encrypted`)

=== P9: all NAMESPACE exports documented ===
(zero UNDOCUMENTED = OK) — 33 exports covered, none invented
```

## Deviations from spec

- **NAMESPACE has 33 `export()` lines, not 34** (spec's "34" is off-by-one — likely counted the roxygen comment header). P9 probe reads the real NAMESPACE; all 33 documented, none invented. `log.md` records 33.
- **L441/L563 are the PRE-fix-#39 positions** of the phq8score raw-guard (verified via `git show 90ef649^`). Post-fix parse-once guards moved to L446/L575. The doc flags the historical positions exactly per P5 AND accurately describes the current state (raw-guard STYLE persists on sibling criteria fields L440-450 / L568-580).
- **macOS BSD grep lacks `-P`/`\K`**: the spec's `grep -iP`/`grep -oP` probes don't run on this machine. Used equivalent `-E` regexes + `sed`/`rg -P` extraction — same semantics, identical results.
- **okf-bundle skill Step-7 mdlink script has a latent bug**: `rg -no` emits `path:line:` prefixes, so every absolute-style mdlink (`](/…`) is falsely reported broken. Worked around with same-dir relative links + `../modules/` cross-dir links (verbatim script zero-output; all links resolve — verified per-file).
- **P7 fully run** (R CMD build completes in seconds here) — no fallback to line-presence-only needed.
- **3 commits** instead of 2: added `docs(plans)` commit for the AC-1.1 living-plan update (status complete + decision log + surprises).

## Self-Review

- [x] All ACs exercised by probes (P1–P9)
- [x] Predicates match spec
- [x] Negative cases covered (silent gitignore no-op, stub bundle, invariant omission, Rbuildignore removal, workflow modification, NAMESPACE drift, broken links, conformance failure)
- [x] Verification medium satisfied (code + manual prose residual)
- [x] Design intent respected (§1 invariant encoding, §2 pure/effectful frontmatter, §3 file-boundary concepts, §4 responsibility incl. what-NOT, §5 interface quick-ref)
- [x] No scope creep (.Rbuildignore/workflow/build-dashboard.sh untouched; clobber risk documented only)
