### PR TITLE
[chore] Init codegraph index + gitignore + README regen docs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@
 ^inst/dashboard/
 ^renv$
 ^renv\.lock$
+^\.codegraph$

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ planning.md
 .opencode/plans/**/status.md
 .opencode/ci-status/
 .opencode/traces/
+# codegraph index (machine-local, regenerate with `codegraph init`)
+.codegraph/

--- a/.opencode/plans/repo-usability/AC-1.2.md
+++ b/.opencode/plans/repo-usability/AC-1.2.md
@@ -2,7 +2,7 @@
 ac: 1.2
 depends_on: none (serialized after AC-1.1 in W1 — both touch .gitignore)
 risk: low
-status: spec
+status: complete
 ---
 
 # AC-1.2: codegraph index init + gitignore + README regen note
@@ -51,13 +51,13 @@ status: spec
 - **Risk level:** low. Reversible via `codegraph uninit` + git revert.
 
 ### Progress
-- [ ] index initialized — pending
+- [x] index initialized — 2026-08-13 (20 files, 138 nodes, 257 edges; query hit R/redcap_api.R:37)
 
 ### Decision Log
 - spec-resolved — `.Rbuildignore` entry downgraded to SHOULD (R CMD build never runs in CI).
 
 ### Surprises & Discoveries
-- (none yet)
+- Probe step 10 (`git diff main -- .gitignore | rg '^-[^-]'` empty) is UNSATISFIABLE as written: HEAD .gitignore's last line `.opencode/traces/` has NO trailing newline, so ANY append makes git diff show that line as a `-`/`+` pair (newline added). Verified with minimal repro. Content is fully preserved (AC-1.1 entries docs/*, !docs/okf/, planning.md, opencode lines all present) — the single `-` line is a false positive, not a clobber. Deviation logged; implementers should replace step 10 with a content-preservation check (e.g. compare `git show HEAD:.gitignore` lines ⊆ working tree lines).
 
 ### Idempotence & Recovery
 - Safe retry: `codegraph init` is idempotent (re-runs refresh index).

--- a/README.md
+++ b/README.md
@@ -106,6 +106,22 @@ Otherwise, the pre-commit hooks are ususally pretty explicit about what has spec
 
 If you really get stuck, you can file an issue with the Github repo with a bug report, including the full text of the pre-commit output + any other necessary context.
 
+### Set up the codegraph index for agent navigation
+
+We use [codegraph](https://github.com/paul-gauthier/codegraph) to build a symbol-level index of this repo so coding agents get accurate codebase navigation. The index is a machine-local artifact: `.codegraph/` is gitignored and is **never committed** to the repo.
+
+To initialize (or regenerate) the index, run from the repo root:
+
+```
+codegraph init
+```
+
+Regenerate the index whenever it goes stale:
+
+- after structural changes to `R/` files (new files, moved/renamed functions)
+- before starting an agent session that needs codebase navigation
+- any time `codegraph status` reports the index is out of date
+
 ### Create an issue with a description of what you're doing
 
 In the Github [repo](https://github.com/moodlab/abmdash/issues) create a new issue with a description of what your code changes will do. If you're not sure where to start with the description you can look at previous issues.


### PR DESCRIPTION
## Summary
Initialize a codegraph index at repo root for symbol-level agent navigation; gitignore the index (never committed); add `.Rbuildignore` entry; document regeneration in README.

## Issue
Closes #41

## ACs implemented
- [x] `codegraph init` ran at repo root; `codegraph query call_redcap_api` returns hit in `R/redcap_api.R:37` (R extraction proven)
- [x] `.codegraph/` appended to `.gitignore` AND `git ls-files .codegraph/` is empty (never tracked)
- [x] README has codegraph section: `codegraph init` command + when-to-regen trigger + gitignore/not-committed statement
- [x] `.gitignore` edit is append-only relative to AC-1.1 — no AC-1.1 entries clobbered (verified content)
- [x] SHOULD: `.Rbuildignore` contains `^\.codegraph$`

## Probe output (AC-1.2 MUST chain + SHOULD)
```
codegraph query call_redcap_api  → PASS (function call_redcap_api @ R/redcap_api.R:37)
codegraph status                 → PASS (Files: 20, Nodes: 138, Edges: 257, "Index is up to date")
git check-ignore .codegraph/     → PASS (.codegraph/)
git check-ignore .codegraph/codegraph.db → PASS (.codegraph/codegraph.db)
git ls-files .codegraph/ empty   → PASS (0 tracked files)
README has 'codegraph init'      → PASS
README regen trigger             → PASS ("Regenerate the index whenever it goes stale…")
README gitignore/not-committed   → PASS (".codegraph/ is gitignored and is **never committed**")
.gitignore contains 'codegraph'  → PASS
git diff main -- .gitignore no '-'-lines → FAIL (false positive, see Deviation)
SHOULD: .Rbuildignore ^\.codegraph$ → PASS
```

### Deviation (documented)
Probe step 10 (`test -z "$(git diff main -- .gitignore | rg '^-[^-]')"`) is **unsatisfiable as written**: HEAD `.gitignore`'s last line `.opencode/traces/` has **no trailing newline**, so any append makes git show that line as a `-`/`+` pair (newline added). Minimal repro confirms this is inherent to git diff, not to this edit. Content is fully preserved — `git diff` shows only the single `-.opencode/traces/` line re-added on the `+` side, plus 2 pure additions; all AC-1.1 entries (`docs/*`, `!docs/okf/`, `planning.md`, opencode transient lines) verified present in working tree. No clobber. Logged in plan file Surprises & Discoveries.

## Test plan
- [x] All AC-1.2 probe commands run (9/10 MUST + SHOULD pass; step 10 false positive documented)
- [x] `git ls-files .codegraph/` empty — index never committed