### PR TITLE
[chore] Refactor 5 small R modules for readability (zero behavior change)

### DIFF
--- a/.opencode/plans/repo-usability/AC-3.8.md
+++ b/.opencode/plans/repo-usability/AC-3.8.md
@@ -2,7 +2,7 @@
 ac: 3.8
 depends_on: AC-3.4
 risk: medium
-status: spec
+status: complete
 ---
 
 # AC-3.8: Refactor 5 small modules (ZERO behavior change)
@@ -50,11 +50,13 @@ status: spec
 - risk: medium.
 
 ### Progress
-- [ ] refactor — pending
+- [x] refactor — complete 2026-08-13 (5 commits: 8f756df compliance_summary, 4e147b5 compliance_tracking, bdc1ae4 demographics, a901eb8 week12_tracking, 7640e03 run_initial_function; each passed make test; all probes green)
 ### Decision Log
 - spec-resolved — encrypt_dashboard strictly refactor (no signature change); cap-at-16 logged as lock gap (non-blocking).
 ### Surprises & Discoveries
-- (none yet)
+- unlist(list-of-lists, recursive = FALSE) does NOT drop NULL elements nested inside inner lists (only empty inner lists vanish) — explicit NULL-filter needed after flattening in build_followup_rows wiring (verified in R before committing).
+- rg/grep -c exits 1 on zero matches, breaking && chains — check per-file separately or use `;`.
+- Rscript -e run without an explicit workdir executes in the session default cwd — a relative-path write silently hit the primary checkout (abmdash) instead of the worktree. Always pass workdir or absolute paths.
 ### Idempotence & Recovery
 - Safe retry: per-commit lock-green.
 - Rollback: git revert; lock suite catches drift.

--- a/R/compliance_summary.R
+++ b/R/compliance_summary.R
@@ -38,40 +38,12 @@ get_participant_summary <- function(sheet_url,
   # Get unique participants
   unique_ids <- unique(compliance$id)
 
-  summary_list <- list()
-
-  for (i in seq_along(unique_ids)) {
-    participant_id <- unique_ids[i]
-    participant_data <- compliance[compliance$id == participant_id, ]
-
-    # Get the most recent week's data
-    latest_week <- participant_data[which.max(participant_data$time_from_start), ]
-
-    # Calculate totals across all weeks
-    total_completed <- sum(participant_data$sess_cnt, na.rm = TRUE)
-    weeks_from_start <- latest_week$time_from_start
-    expected_total <- round(weeks_from_start * sessions_per_week, 2)
-
-    # Cap expected sessions at 16 (4 weeks * 4 sessions/week)
-    expected_total <- min(expected_total, 16)
-
-    behind <- expected_total - total_completed
-
-    # Determine current week (1-4)
-    current_week <- min(ceiling(weeks_from_start), 4)
-
-    summary_list[[i]] <- data.frame(
-      id = participant_id,
-      current_week = current_week,
-      weeks_from_start = round(weeks_from_start, 2),
-      total_sessions_completed = total_completed,
-      expected_sessions = expected_total,
-      sessions_behind = round(behind, 2),
-      start_date = format(latest_week$start - ((current_week - 1) * 7 * 24 * 60 * 60), "%Y-%m-%d"),
-      stringsAsFactors = FALSE
-    )
-  }
-
+  summary_list <- lapply(
+    unique_ids,
+    compute_participant_summary,
+    compliance = compliance,
+    sessions_per_week = sessions_per_week
+  )
   summary <- do.call(rbind, summary_list)
 
   # Sort by sessions behind (most behind first)
@@ -85,6 +57,42 @@ get_participant_summary <- function(sheet_url,
   message("  - Participants on/ahead of schedule: ", sum(summary$sessions_behind <= 0))
 
   return(summary)
+}
+
+# Internal helper: compute one participant's summary row from their compliance
+# rows. The most recent week's time_from_start drives current_week and the
+# expected-session math; expected sessions are capped at 16 (4 weeks * 4
+# sessions/week). Row frame shape matches the exported contract (see
+# get_participant_summary() roxygen @return).
+compute_participant_summary <- function(participant_id, compliance, sessions_per_week) {
+  participant_data <- compliance[compliance$id == participant_id, ]
+
+  # Get the most recent week's data
+  latest_week <- participant_data[which.max(participant_data$time_from_start), ]
+
+  # Calculate totals across all weeks
+  total_completed <- sum(participant_data$sess_cnt, na.rm = TRUE)
+  weeks_from_start <- latest_week$time_from_start
+  expected_total <- round(weeks_from_start * sessions_per_week, 2)
+
+  # Cap expected sessions at 16 (4 weeks * 4 sessions/week)
+  expected_total <- min(expected_total, 16)
+
+  behind <- expected_total - total_completed
+
+  # Determine current week (1-4)
+  current_week <- min(ceiling(weeks_from_start), 4)
+
+  data.frame(
+    id = participant_id,
+    current_week = current_week,
+    weeks_from_start = round(weeks_from_start, 2),
+    total_sessions_completed = total_completed,
+    expected_sessions = expected_total,
+    sessions_behind = round(behind, 2),
+    start_date = format(latest_week$start - ((current_week - 1) * 7 * 24 * 60 * 60), "%Y-%m-%d"),
+    stringsAsFactors = FALSE
+  )
 }
 
 

--- a/R/compliance_tracking.R
+++ b/R/compliance_tracking.R
@@ -91,18 +91,7 @@ get_compliance_report <- function(sheet_url,
   start_dates <- start_dates[!duplicated(start_dates$id), ]
 
   # Compute weekly dates (weeks 1-4)
-  study_dates_list <- list()
-
-  for (week_num in 1:4) {
-    week_data <- data.frame(
-      id = start_dates$id,
-      week = week_num,
-      start = start_dates$start_trial + ((week_num - 1) * 7 * 24 * 60 * 60),
-      end = start_dates$end_trial + ((week_num - 1) * 7 * 24 * 60 * 60),
-      stringsAsFactors = FALSE
-    )
-    study_dates_list[[week_num]] <- week_data
-  }
+  study_dates_list <- lapply(1:4, build_week_frame, start_dates = start_dates)
 
   # Combine all weeks
   study_dates <- do.call(rbind, study_dates_list)
@@ -147,6 +136,20 @@ get_compliance_report <- function(sheet_url,
     compliance = compliance,
     short_sessions = short_sessions
   ))
+}
+
+# Internal helper: build the week-N start/end frame for every participant's
+# start_trial/end_trial. `week_num` is an integer week index (1:4); the frame
+# keeps the id char / week integer / start & end POSIXct types of the exported
+# compliance contract (locked by test-compliance-tracking.R).
+build_week_frame <- function(week_num, start_dates) {
+  data.frame(
+    id = start_dates$id,
+    week = week_num,
+    start = start_dates$start_trial + ((week_num - 1) * 7 * 24 * 60 * 60),
+    end = start_dates$end_trial + ((week_num - 1) * 7 * 24 * 60 * 60),
+    stringsAsFactors = FALSE
+  )
 }
 
 

--- a/R/demographics.R
+++ b/R/demographics.R
@@ -49,9 +49,7 @@ get_demographic_summary <- function(report_id = "13349", enrolled_ids = NULL) {
   age_data <- demo_raw[demo_raw$redcap_event_name == "eligibility_screen_arm_1", ]
   age_data$age <- NA
   if ("interview_age" %in% names(age_data)) {
-    birthdays <- as.Date(age_data$interview_age)
-    today <- Sys.Date()
-    age_data$age <- floor(as.numeric(difftime(today, birthdays, units = "days")) / 365.25)
+    age_data$age <- compute_age(age_data$interview_age)
   }
 
   # Merge demographics
@@ -76,6 +74,14 @@ get_demographic_summary <- function(report_id = "13349", enrolled_ids = NULL) {
   demo_merged$age <- age_data$age[age_match]
 
   return(demo_merged)
+}
+
+# Internal helper: whole years between `today` and each interview date, using
+# the 365.25-day year (floor, same math as before extraction). Exact ages are
+# pinned by the frozen-clock tripwire in test-demographics.R.
+compute_age <- function(interview_age, today = Sys.Date()) {
+  birthdays <- as.Date(interview_age)
+  floor(as.numeric(difftime(today, birthdays, units = "days")) / 365.25)
 }
 
 

--- a/R/run_initial_function.R
+++ b/R/run_initial_function.R
@@ -111,9 +111,10 @@ get_enrollment_targets <- function() {
 }
 
 # Internal helper: the first path in `paths` that exists, or NA if none do.
-# Uses base file.exists (NOT fs::file_exists) so the base mock in
-# test-run-initial-function.R (L97 lock) continues to trip every candidate
-# and the verbatim stop string fires.
+# Uses base file.exists (NOT fs::file_exists) so the mock in
+# test-run-initial-function.R keeps the verbatim stop firing. Called once on the
+# whole vector; the "" that system.file() returns when extdata is absent is
+# skipped because file.exists("") is FALSE (the old `path != ""` guard).
 resolve_first_existing <- function(paths) {
   paths[file.exists(paths)][1]
 }

--- a/R/run_initial_function.R
+++ b/R/run_initial_function.R
@@ -31,22 +31,35 @@ encrypt_dashboard <- function() {
   }
 
   # Determine the correct docs path - use absolute path for Docker
-  docs_path <- "/app/docs"
-  if (!file.exists(docs_path)) {
-    # Fallback to relative paths if not in Docker
-    if (file.exists("../../docs")) {
-      docs_path <- "../../docs"
-    } else if (file.exists("docs")) {
-      docs_path <- "docs"
-    } else {
-      cat("Could not find docs directory, skipping encryption\n")
-      return(invisible(NULL))
-    }
+  docs_path <- resolve_docs_path()
+  if (is.na(docs_path)) {
+    cat("Could not find docs directory, skipping encryption\n")
+    return(invisible(NULL))
   }
 
   cat("Encrypting files in:", docs_path, "\n")
 
   return(invisible(NULL))
+}
+
+# Internal helper: resolve the docs directory, preferring the absolute Docker
+# path (/app/docs), then the relative fallbacks. Returns NA when no docs
+# directory exists anywhere (caller handles the skip message).
+resolve_docs_path <- function() {
+  # Use absolute path for Docker
+  if (file.exists("/app/docs")) {
+    return("/app/docs")
+  }
+
+  # Fallback to relative paths if not in Docker
+  if (file.exists("../../docs")) {
+    return("../../docs")
+  }
+  if (file.exists("docs")) {
+    return("docs")
+  }
+
+  NA_character_
 }
 
 #' Get current time in Central Time Zone
@@ -85,15 +98,9 @@ get_enrollment_targets <- function() {
     "../../inst/extdata/enrollment_targets.csv"
   )
 
-  csv_path <- NULL
-  for (path in possible_paths) {
-    if (file.exists(path) && path != "") {
-      csv_path <- path
-      break
-    }
-  }
+  csv_path <- resolve_first_existing(possible_paths)
 
-  if (is.null(csv_path)) {
+  if (is.na(csv_path)) {
     stop("Could not find enrollment_targets.csv file")
   }
 
@@ -101,4 +108,12 @@ get_enrollment_targets <- function() {
   enrollment_data <- read.csv(csv_path, stringsAsFactors = FALSE)
 
   return(enrollment_data)
+}
+
+# Internal helper: the first path in `paths` that exists, or NA if none do.
+# Uses base file.exists (NOT fs::file_exists) so the base mock in
+# test-run-initial-function.R (L97 lock) continues to trip every candidate
+# and the verbatim stop string fires.
+resolve_first_existing <- function(paths) {
+  paths[file.exists(paths)][1]
 }

--- a/R/week12_tracking.R
+++ b/R/week12_tracking.R
@@ -122,9 +122,6 @@ get_upcoming_followups <- function(days_ahead = 14) {
   recent_completions$days_to_week16 <- as.numeric(recent_completions$week16_due_date - today)
   recent_completions$days_to_week28 <- as.numeric(recent_completions$week28_due_date - today)
   
-  # Create a list to collect all upcoming follow-ups
-  all_followups <- list()
-  
   # Check each participant for incomplete follow-ups
   followup_rows <- lapply(
     split(recent_completions, seq_len(nrow(recent_completions))),

--- a/R/week12_tracking.R
+++ b/R/week12_tracking.R
@@ -21,15 +21,7 @@ get_upcoming_followups <- function(days_ahead = 14) {
   logs <- get_redcap_logs(begin_time = begin_time)
   
   if (is.null(logs) || length(logs) == 0) {
-    return(data.frame(
-      record_id = character(0),
-      follow_up_type = character(0),
-      w4_completion_date = character(0),
-      due_date = character(0),
-      days_until_due = numeric(0),
-      status = character(0),
-      stringsAsFactors = FALSE
-    ))
+    return(empty_followup_frame())
   }
   
   # Convert to data frame if needed
@@ -49,15 +41,7 @@ get_upcoming_followups <- function(days_ahead = 14) {
   }
   
   if (nrow(logs_df) == 0) {
-    return(data.frame(
-      record_id = character(0),
-      follow_up_type = character(0),
-      w4_completion_date = character(0),
-      due_date = character(0),
-      days_until_due = numeric(0),
-      status = character(0),
-      stringsAsFactors = FALSE
-    ))
+    return(empty_followup_frame())
   }
   
   # Look for W4 Acute [IN-PERSON] completions
@@ -68,15 +52,7 @@ get_upcoming_followups <- function(days_ahead = 14) {
   
   
   if (nrow(w4_logs) == 0) {
-    return(data.frame(
-      record_id = character(0),
-      follow_up_type = character(0),
-      w4_completion_date = character(0),
-      due_date = character(0),
-      days_until_due = numeric(0),
-      status = character(0),
-      stringsAsFactors = FALSE
-    ))
+    return(empty_followup_frame())
   }
   
   # Parse timestamps and filter valid records
@@ -84,15 +60,7 @@ get_upcoming_followups <- function(days_ahead = 14) {
   w4_logs_with_records <- w4_logs[w4_logs$record != "" & !is.na(w4_logs$record), ]
   
   if (nrow(w4_logs_with_records) == 0) {
-    return(data.frame(
-      record_id = character(0),
-      follow_up_type = character(0),
-      w4_completion_date = character(0),
-      due_date = character(0),
-      days_until_due = numeric(0),
-      status = character(0),
-      stringsAsFactors = FALSE
-    ))
+    return(empty_followup_frame())
   }
   
   # Get most recent W4 completion per record
@@ -110,15 +78,7 @@ get_upcoming_followups <- function(days_ahead = 14) {
   recent_completions_list <- recent_completions_list[!sapply(recent_completions_list, is.null)]
   
   if (length(recent_completions_list) == 0) {
-    return(data.frame(
-      record_id = character(0),
-      follow_up_type = character(0),
-      w4_completion_date = character(0),
-      due_date = character(0),
-      days_until_due = numeric(0),
-      status = character(0),
-      stringsAsFactors = FALSE
-    ))
+    return(empty_followup_frame())
   }
   
   recent_completions <- do.call(rbind, recent_completions_list)
@@ -140,6 +100,11 @@ get_upcoming_followups <- function(days_ahead = 14) {
   w12_completed_records <- unique(w12_completed_logs$record[w12_completed_logs$record != ""])
   w16_completed_records <- unique(w16_completed_logs$record[w16_completed_logs$record != ""])
   w28_completed_records <- unique(w28_completed_logs$record[w28_completed_logs$record != ""])
+  completed_records <- list(
+    "Week 12" = w12_completed_records,
+    "Week 16" = w16_completed_records,
+    "Week 28" = w28_completed_records
+  )
   
   
   # Calculate follow-up dates and status
@@ -161,63 +126,15 @@ get_upcoming_followups <- function(days_ahead = 14) {
   all_followups <- list()
   
   # Check each participant for incomplete follow-ups
-  for (i in 1:nrow(recent_completions)) {
-    row <- recent_completions[i, ]
-    record_id <- row$record
-    
-    # Skip withdrawn participants entirely
-    if (record_id %in% withdrawn_records) {
-      next
-    }
-    
-    # Week 12 - only show if not completed and within timeframe
-    if (abs(row$days_to_week12) <= days_ahead && !record_id %in% w12_completed_records) {
-      all_followups[[length(all_followups) + 1]] <- data.frame(
-        record_id = record_id,
-        follow_up_type = "Week 12",
-        w4_completion_date = as.character(row$completion_date),
-        due_date = as.character(row$week12_due_date),
-        days_until_due = row$days_to_week12,
-        status = ifelse(row$days_to_week12 < 0, 
-                       paste("Overdue by", abs(row$days_to_week12), "days"),
-                       ifelse(row$days_to_week12 == 0, "Due Today",
-                             paste("Due in", row$days_to_week12, "days"))),
-        stringsAsFactors = FALSE
-      )
-    }
-    
-    # Week 16 - only show if not completed and within timeframe
-    if (abs(row$days_to_week16) <= days_ahead && !record_id %in% w16_completed_records) {
-      all_followups[[length(all_followups) + 1]] <- data.frame(
-        record_id = record_id,
-        follow_up_type = "Week 16",
-        w4_completion_date = as.character(row$completion_date),
-        due_date = as.character(row$week16_due_date),
-        days_until_due = row$days_to_week16,
-        status = ifelse(row$days_to_week16 < 0, 
-                       paste("Overdue by", abs(row$days_to_week16), "days"),
-                       ifelse(row$days_to_week16 == 0, "Due Today",
-                             paste("Due in", row$days_to_week16, "days"))),
-        stringsAsFactors = FALSE
-      )
-    }
-    
-    # Week 28 - only show if not completed and within timeframe
-    if (abs(row$days_to_week28) <= days_ahead && !record_id %in% w28_completed_records) {
-      all_followups[[length(all_followups) + 1]] <- data.frame(
-        record_id = record_id,
-        follow_up_type = "Week 28",
-        w4_completion_date = as.character(row$completion_date),
-        due_date = as.character(row$week28_due_date),
-        days_until_due = row$days_to_week28,
-        status = ifelse(row$days_to_week28 < 0, 
-                       paste("Overdue by", abs(row$days_to_week28), "days"),
-                       ifelse(row$days_to_week28 == 0, "Due Today",
-                             paste("Due in", row$days_to_week28, "days"))),
-        stringsAsFactors = FALSE
-      )
-    }
-  }
+  followup_rows <- lapply(
+    split(recent_completions, seq_len(nrow(recent_completions))),
+    build_followup_rows,
+    withdrawn_records = withdrawn_records,
+    completed_records = completed_records,
+    days_ahead = days_ahead
+  )
+  all_followups <- unlist(followup_rows, recursive = FALSE)
+  all_followups <- all_followups[!vapply(all_followups, is.null, logical(1))]
   
   # Combine all follow-ups
   if (length(all_followups) > 0) {
@@ -227,14 +144,64 @@ get_upcoming_followups <- function(days_ahead = 14) {
     rownames(result) <- NULL
     return(result)
   } else {
-    return(data.frame(
-      record_id = character(0),
-      follow_up_type = character(0),
-      w4_completion_date = character(0),
-      due_date = character(0),
-      days_until_due = numeric(0),
-      status = character(0),
-      stringsAsFactors = FALSE
-    ))
+    return(empty_followup_frame())
   }
+}
+
+# Internal helper: the locked empty follow-up frame. Columns and types are
+# pinned by test-week12-tracking.R: record_id/follow_up_type/w4_completion_date/
+# due_date/status character, days_until_due double.
+empty_followup_frame <- function() {
+  data.frame(
+    record_id = character(0),
+    follow_up_type = character(0),
+    w4_completion_date = character(0),
+    due_date = character(0),
+    days_until_due = numeric(0),
+    status = character(0),
+    stringsAsFactors = FALSE
+  )
+}
+
+# Internal helper: the 0-3 follow-up rows for one participant's most recent W4
+# completion. Withdrawn participants yield no rows; each follow-up type yields
+# a row only when it is not already completed and falls within the look-ahead
+# window. Status strings are locked verbatim by test-week12-tracking.R,
+# including the unpluralized "Due in 1 days".
+build_followup_rows <- function(completion, withdrawn_records, completed_records, days_ahead) {
+  record_id <- completion$record
+
+  # Skip withdrawn participants entirely
+  if (record_id %in% withdrawn_records) {
+    return(list())
+  }
+
+  build_one <- function(follow_up_type, due_date_col, days_until_col) {
+    days_until_due <- completion[[days_until_col]]
+
+    # Only show if not completed and within timeframe
+    if (abs(days_until_due) <= days_ahead &&
+        !record_id %in% completed_records[[follow_up_type]]) {
+      data.frame(
+        record_id = record_id,
+        follow_up_type = follow_up_type,
+        w4_completion_date = as.character(completion$completion_date),
+        due_date = as.character(completion[[due_date_col]]),
+        days_until_due = days_until_due,
+        status = ifelse(days_until_due < 0,
+                       paste("Overdue by", abs(days_until_due), "days"),
+                       ifelse(days_until_due == 0, "Due Today",
+                             paste("Due in", days_until_due, "days"))),
+        stringsAsFactors = FALSE
+      )
+    } else {
+      NULL
+    }
+  }
+
+  list(
+    build_one("Week 12", "week12_due_date", "days_to_week12"),
+    build_one("Week 16", "week16_due_date", "days_to_week16"),
+    build_one("Week 28", "week28_due_date", "days_to_week28")
+  )
 }

--- a/tests/testthat/test-week12-tracking.R
+++ b/tests/testthat/test-week12-tracking.R
@@ -171,3 +171,17 @@ test_that("get_upcoming_followups returns locked empty frame when no W4 matches"
                          "due_date", "days_until_due", "status"))
   expect_type(result$days_until_due, "double")
 })
+
+test_that("get_upcoming_followups returns locked empty frame when every window is out of range", {
+  local_isolated_env()
+  with_fixed_clock("2026-03-20 12:00:00", tz = "UTC")
+  logs <- data.frame(timestamp = "2026-02-09 10:00", username = "u1",
+    action = "Completed W4 Acute [IN-PERSON]", details = "", record = "P020",
+    stringsAsFactors = FALSE)                    # W12 due in 17d > days_ahead 14
+  local_mocked_bindings(get_redcap_logs = function(begin_time = NULL, ...) logs)
+  result <- get_upcoming_followups()
+  expect_equal(nrow(result), 0)
+  expect_named(result, c("record_id", "follow_up_type", "w4_completion_date",
+                         "due_date", "days_until_due", "status"))
+  expect_type(result$days_until_due, "double")
+})


### PR DESCRIPTION
## Summary
Zero-behavior refactor of 5 small R modules for readability: kill `for` loops in compliance_summary, compliance_tracking, week12_tracking, run_initial_function via named base-R helpers (lapply/split + do.call(rbind)); minimal demographics cleanup; strict encrypt_dashboard refactor (no signature change). 11 exports byte-identical — NAMESPACE, DESCRIPTION, and man/ all diff empty.

## Issue
Closes #59

## Per-module commits
| Commit | Module | Change |
|---|---|---|
| 8f756df | compliance_summary.R | extract `compute_participant_summary` + lapply/do.call(rbind) |
| 4e147b5 | compliance_tracking.R | extract `build_week_frame` + lapply(1:4, ...) (integer week) |
| bdc1ae4 | demographics.R | extract `compute_age` (round(x,1) percentage path untouched) |
| a901eb8 | week12_tracking.R | extract `build_followup_rows` + split/lapply; dedupe 6 empty-frame returns into `empty_followup_frame` |
| 7640e03 | run_initial_function.R | `resolve_first_existing` (base file.exists, verbatim stop, same filename); `resolve_docs_path` for encrypt_dashboard (/app/docs preserved) |
| bbc37f5 | plan | AC-3.8 marked complete |

Each commit passes `make test` (bisectable).

## Probes (all green)
- `make test` → FAIL 0 | PASS 471 (1 skip: ABS creds unset locally — expected)
- `rg 'for\s*\('` on the 4 files → 0, 0, 0, 0
- `git diff --exit-code NAMESPACE DESCRIPTION man/` → empty (document() idempotent, RoxygenNote 7.3.2)
- ``rg '`%||%` <- ' R/`` → exactly 1 (redcap_api.R:502)

## Test plan
- [x] All 17 test files green (incl. 5 lock files + test-faq-verbatim OKF link)
- [x] Lock suite drift traps untouched: "50%"/"16.7%" strings, 2.73 difftime weeks, "Due in 1 days", empty-frame integer week, CDT string, L97 stop verbatim, empty-compliance error path
- [x] PR review findings resolved (n/a — first pass)

## Self-Review
- [x] All ACs exercised by tests
- [x] Predicates match spec
- [x] Negative case tested
- [x] Verification medium satisfied (code)
- [x] Design intent respected
- [x] No scope creep
