### PR TITLE
[chore] Create repo-level abmdash-guide skill (learn-the-repo)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^renv$
 ^renv\.lock$
 ^\.codegraph$
+^\.opencode$

--- a/.opencode/plans/repo-usability/AC-4.1.md
+++ b/.opencode/plans/repo-usability/AC-4.1.md
@@ -1,0 +1,42 @@
+---
+feature: repo-usability
+ac: 4.1
+status: complete
+title: "[chore] Create repo-level abmdash-guide skill (learn-the-repo)"
+---
+
+# AC-4.1 — Repo-level abmdash-guide skill
+
+Slice from `repo-usability`. Issue #66. Spec block in issue body (12 conjuncts).
+
+## Progress
+
+- [x] 2026-08-13 — Read issue #66 + spec (12 conjuncts); plan file absent → spec carried in issue body. Synced branch 66-abmdash-guide with origin/main (was behind 5).
+- [x] 2026-08-13 — Ground-truth gathering: counted redcap_api.R top-level functions (25, 9 exported → 16 internal), NAMESPACE exports (33), R/ files (10), CI jobs (build-image, build-dashboard), cron `0 6 * * *`, Dockerfile stages (2× rocker/r-ver:4.5.1, node18 + staticrypt), Makefile targets (7), RECORDING.md at root, env var names via Sys.getenv greps.
+- [x] 2026-08-13 — Wrote `.opencode/skills/abmdash-guide/SKILL.md` (frontmatter name+description, 8 top-level sections: purpose, architecture, module map, data sources, local run, behavior-lock, verify-understanding, non-engineer guide). No debug section (AC-4.2 scope guard).
+- [x] 2026-08-13 — Appended `^.opencode$` to `.Rbuildignore` after `^.codegraph$`.
+- [x] 2026-08-13 — Verification: file tracked, frontmatter, accuracy clauses, pipeline keywords, link-existence loop. Committed + pushed + PR created.
+
+## Decision Log
+
+- **Grounded count over OKF**: redcap_api internal helpers stated as 16 (25 top-level, 9 exported) + explicit stale-OKF note pointing to R/redcap_api.R as source of truth. Issue required this (AC-4.1.4).
+- **R file count**: stated 10, explicitly calling out OKF index omission of week12_tracking.R (boundary-rule skip, 1 export) (AC-4.1.5).
+- **Exports**: stated 33, counted from NAMESPACE (AC-4.1.6).
+- **Link style**: relative-style repo-root links (`docs/okf/...`, `R/...`, no leading `/`) per okf-bundle validator false-positive avoidance (AC-4.1.10).
+- **Behavior-lock framing**: "tests ARE the spec" + RECORDING.md at repo ROOT, referencing test-redcap-behavior-lock.R, test-snapshot-lock.R, helper-harness.R (≥2 of 3) (AC-4.1.8).
+- **Section structure**: 8 top-level sections; verify-understanding (§7) + non-engineer (§8) satisfy dual audience (AC-4.1.9); no debug-workflow top-level section (AC-4.1.11).
+
+## Surprises & Discoveries
+
+- Plan file `.opencode/plans/repo-usability/AC-4.1.md` did not exist at branch creation — spec lives entirely in the issue body's Executable Spec block. Not a blocker; issue body is self-contained.
+- redcap_api.R top-level function count (25) is exact via `<- function` grep; 16 internal = 25 − 9 exported (NAMESPACE). OKF's "2 internal helpers" undercounts by 14 — consistent with wave-3b refactor drift the issue warned about.
+- gsheet_api.R auths via `GOOGLE_SERVICE_ACCOUNT_JSON` (service account), not OAuth2 flow as its roxygen title says — env-var grep settled the local-run section.
+- docs/okf/log.md already records the 33-export cross-reference and the week12_tracking skip — useful cross-check that the stale bits are index/interface prose, not the export count.
+
+## Verification Notes
+
+- `git ls-files --error-unmatch .opencode/skills/abmdash-guide/SKILL.md` ✓
+- Accuracy greps: no `2 internal`, no unqualified `9 R files` ✓
+- Pipeline keywords: `0 6 * * *`, build-image, build-dashboard, staticrypt, RECORDING.md ✓
+- Link-existence loop over all `](...)` targets: all resolve on disk ✓
+- Probe outputs pasted into PR body.

--- a/.opencode/skills/abmdash-guide/SKILL.md
+++ b/.opencode/skills/abmdash-guide/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: abmdash-guide
+description: >-
+  Learn-the-repo walkthrough for the abmdash R package — the private,
+  staticrypt-encrypted Quarto dashboard for the ABM study, deployed to GitHub
+  Pages. Explains repo purpose, the render-and-encrypt pipeline (R package →
+  quarto → staticrypt → docs/ commit), CI jobs, the 10 R module map, data
+  sources (REDCap, Google Sheets, Google Calendar, ABS portal), local run via
+  the Makefile, and the behavior-lock test suite as executable specs. Use when
+  someone asks to learn abmdash, understand how this repo works, what modules
+  exist, or how the dashboard architecture is put together.
+---
+
+# abmdash — Learn the Repo
+
+A single-file orientation for anyone (agent or human) new to this repository.
+Read top to bottom once; then use the module map as a lookup table. For
+troubleshooting (not covered here) see the [troubleshooting vignettes](vignettes/).
+
+## 1. Repo Purpose
+
+`abmdash` is an R package (see [DESCRIPTION](DESCRIPTION)) that builds the ABM
+project dashboard: a **private** summary of study data (screening, enrollment,
+compliance, follow-ups) for the Attention Bias Modification study. The output is
+a static Quarto dashboard, encrypted at rest with staticrypt, and published to
+GitHub Pages. The repo is both the data-access layer and the publishing
+pipeline — there is no running server.
+
+Three facts shape every decision in this codebase:
+
+- **The dashboard must stay private.** Every build step exists to keep the
+  rendered HTML encrypted (staticrypt) and the credentials out of the repo.
+- **It is read-mostly glue.** The R package is a thin effectful shell over
+  external APIs (REDCap, Google Sheets, Google Calendar, the ABS portal) that
+  transforms data into data frames for the dashboard pages.
+- **Behavior is locked, not just tested.** The test suite replays recorded API
+  traffic offline and pins output snapshots — the tests ARE the executable
+  spec (see [§6](#6-behavior-lock-suite-as-executable-specs)).
+
+## 2. Architecture
+
+A daily pipeline turns API data into an encrypted, published dashboard:
+
+```
+R package (R/*.R)
+  → Quarto render (inst/dashboard) — pages written from package functions
+  → staticrypt encrypt (build-dashboard.sh) — password-protect the HTML
+  → commit rendered docs/ → GitHub Pages
+```
+
+Key moving parts:
+
+- **CI workflow** [.github/workflows/build-dashboard.yml](.github/workflows/build-dashboard.yml):
+  - `build-image` job — builds the Docker image (2-stage
+    `rocker/r-ver:4.5.1`, node 18 + staticrypt installed in stage 2; see
+    [Dockerfile](Dockerfile)).
+  - `build-dashboard` job (needs `build-image`) — runs the render +
+    encrypt + commit step via [build-dashboard.sh](build-dashboard.sh).
+  - Scheduled by **cron `0 6 * * *`** (daily at 6 AM UTC).
+- **Dockerfile** — two stages, both `FROM rocker/r-ver:4.5.1`; stage 2 adds
+  Node.js 18 and `staticrypt` via npm.
+- **Output contract** — encrypted dashboard lands in `docs/` (`index.html` +
+  `site_libs/` + `.staticrypt.json`) and is served by GitHub Pages. `docs/` is
+  gitignored-then-committed by the pipeline (see [build-dashboard.sh](build-dashboard.sh)).
+- **Tests** — a separate workflow [.github/workflows/test.yml](.github/workflows/test.yml)
+  runs the behavior-lock suite on every push (pins R 4.5.1, matching the
+  snapshot R version).
+
+Source of truth for the pipeline details: [Dockerfile](Dockerfile),
+[build-dashboard.sh](build-dashboard.sh), and
+[.github/workflows/build-dashboard.yml](.github/workflows/build-dashboard.yml).
+
+## 3. Module Map
+
+10 R source files under `R/`. Each module is one file; the file boundary IS
+the module boundary (see the OKF bundle at [docs/okf/index.md](docs/okf/index.md)
+for concept docs — note the bundle lags the source, see the accuracy note below).
+
+| Module | Responsibility | Data source |
+|---|---|---|
+| [R/redcap_api.R](R/redcap_api.R) | REDCap API shell: records, metadata, survey completions, logs, reports; derives eligibility, weekly-screening, and enrollment stats | REDCap API |
+| [R/gsheet_api.R](R/gsheet_api.R) | Read a Google Sheet (OAuth2/service account) into a data frame | Google Sheets |
+| [R/gcal_api.R](R/gcal_api.R) | Google Calendar events via service-account auth | Google Calendar |
+| [R/abs_login.R](R/abs_login.R) | ABS admin portal login (Livewire) + CSV download of session data | ABS portal |
+| [R/compliance_summary.R](R/compliance_summary.R) | Participant progress view: current week, sessions completed/behind | Google Sheets |
+| [R/compliance_tracking.R](R/compliance_tracking.R) | Expected vs actual sessions per week from gameplay data | Google Sheets |
+| [R/trad_compliance.R](R/trad_compliance.R) | Traditional ABM compliance from ABS-downloaded session data (mirrors GABM summary shape) | ABS portal CSV |
+| [R/demographics.R](R/demographics.R) | Demographic summary for enrolled participants | REDCap (report 13349) |
+| [R/week12_tracking.R](R/week12_tracking.R) | Upcoming Week 12/16/28 follow-up appointments from W4 Acute in-person completions | REDCap |
+| [R/run_initial_function.R](R/run_initial_function.R) | Starter/example export (`n + n`); kept as the canonical minimal function | — |
+
+**Accuracy notes (the OKF bundle is stale post-refactor):**
+
+- `R/redcap_api.R` has **16 internal helpers** (25 top-level functions total,
+  9 of them exported) — not the two-helper count claimed in
+  [docs/okf/modules/redcap_api.md](docs/okf/modules/redcap_api.md). When you
+  need the real list, read [R/redcap_api.R](R/redcap_api.R) itself — it is the
+  source of truth.
+- There are **10 R files**, not nine: the OKF index omits
+  [R/week12_tracking.R](R/week12_tracking.R) (1 exported function, so the
+  bundle's boundary rule skipped it — it is still a real module).
+- **33 exports** total, as counted in [NAMESPACE](NAMESPACE). When in doubt,
+  trust `NAMESPACE`.
+
+**Habit to form:** the OKF bundle is a curated *map*, not the terrain. For any
+accuracy-sensitive question, verify against `R/*.R`, `NAMESPACE`, and
+`DESCRIPTION` before trusting a concept doc.
+
+## 4. Data Sources
+
+Four external systems feed the dashboard; every one is accessed through a
+dedicated module (no cross-wiring):
+
+1. **REDCap** ([R/redcap_api.R](R/redcap_api.R)) — screening, eligibility,
+   enrollment, demographics, follow-up scheduling. REST API at
+   `redcap.prc.utexas.edu`, token from the `REDCAP_API_TOKEN` env var.
+2. **Google Sheets** ([R/gsheet_api.R](R/gsheet_api.R)) — gameplay session
+   data used by compliance modules. Auth via service account
+   (`GOOGLE_SERVICE_ACCOUNT_JSON`).
+3. **Google Calendar** ([R/gcal_api.R](R/gcal_api.R)) — study events.
+   Service-account auth (`GOOGLE_SERVICE_ACCOUNT_JSON`).
+4. **ABS portal** ([R/abs_login.R](R/abs_login.R)) — the Attention Bias Study
+   admin site; username/password login (`ABS_USERNAME`/`ABS_PASSWORD`) plus a
+   CSV download consumed by [R/trad_compliance.R](R/trad_compliance.R).
+
+The staticrypt password for the rendered dashboard comes from
+`STATICRYPT_PASSWORD` ([R/run_initial_function.R](R/run_initial_function.R)
+shows the encryption call).
+
+## 5. Local Run
+
+You need credentials in `.Renviron` (gitignored — never committed) to reach
+real data: `REDCAP_API_TOKEN`, `GOOGLE_SERVICE_ACCOUNT_JSON`,
+`ABS_USERNAME`, `ABS_PASSWORD`, `STATICRYPT_PASSWORD`. Without them, the
+behavior-lock suite still runs fully offline (recorded fixtures, see §6).
+
+The [Makefile](Makefile) defines the 7 standard targets:
+
+| Target | What it does |
+|---|---|
+| `make test` | Run the full test suite (`devtools::test()`) |
+| `make test-trad` | Run only the trad-compliance tests |
+| `make docker-build` | Build the Docker image locally (same as the CI build-image job) |
+| `make docker-render` | Full local render + encrypt (same as the CI build-dashboard job) |
+| `make docker-test-auth` | Test ABS portal auth inside Docker (needs `.Renviron`) |
+| `make lint` | R package checks (`devtools::check()`) |
+| `make serve` | Serve the rendered `docs/` dashboard locally on port 8000 |
+
+Quickstart: `make test` to verify the environment, then `make serve` and open
+<http://localhost:8000> (the built dashboard must already exist in `docs/`).
+
+## 6. Behavior-Lock Suite as Executable Specs
+
+The tests are not just regression checks — they are the executable
+specification of this package. Every API module is pinned by recorded HTTP
+fixtures replayed offline, plus committed RDS snapshots compared with waldo.
+
+Entry points:
+
+- [tests/testthat/test-redcap-behavior-lock.R](tests/testthat/test-redcap-behavior-lock.R) —
+  the canonical example: offline replay of recorded REDCap traffic, including
+  empty-result and error branches, with no-token guards on every mock file.
+- [tests/testthat/test-snapshot-lock.R](tests/testthat/test-snapshot-lock.R) —
+  snapshot-locking harness (`expect_snapshot_locked()`), pinned RDS files under
+  [tests/testthat/_snaps/snapshot-lock/](tests/testthat/_snaps/snapshot-lock/).
+- [tests/testthat/helper-harness.R](tests/testthat/helper-harness.R) —
+  fixture loading (`load_fixture()`) and isolated-env helpers used by all tests.
+
+The operational rules for recording, redaction, and committing fixtures live in
+**[RECORDING.md](RECORDING.md) at the repo root** (fixture namespacing,
+credential redaction, the no-token commit rule, the `""` vs `NA` convention,
+row-order policy, snapshot version pinning). If you change behavior, you change
+the tests that pin it — the tests ARE the spec.
+
+## 7. Verify Your Understanding
+
+You have the right mental model if you can answer all of these from memory (or
+know exactly which file to open):
+
+1. What does this repo build, and why is the output encrypted?
+2. What are the two CI jobs in
+   [.github/workflows/build-dashboard.yml](.github/workflows/build-dashboard.yml),
+   and when do they run?
+3. Name the 10 modules and which external system each one talks to.
+4. Where do REDCap, Google Sheets, Google Calendar, and the ABS portal each
+   come into the pipeline?
+5. How do you run the full test suite locally, and why does it work without
+   any credentials?
+6. Where does the behavior-lock recording/redaction documentation live?
+
+If you cannot answer #3 and #6 confidently, re-read §3 and §6 before touching
+code.
+
+## 8. Non-Engineer Plain-Language Guide
+
+**What is this?** A website that shows how the ABM study is going — how many
+people have signed up, completed screening, stayed on track with their weekly
+sessions, and who has follow-up appointments coming up. The site is private:
+anyone who opens it needs a password, and the password-protection is applied
+automatically every time the site is rebuilt.
+
+**Where does the data come from?** Four places, all read automatically (nobody
+types numbers in by hand):
+
+- **REDCap** — the study's main database of participants and their progress.
+- **Google Sheets** — where weekly gameplay session data is logged.
+- **Google Calendar** — study events.
+- **The ABS portal** — an administrative website that records traditional ABM
+  sessions.
+
+**How does it get built?** Once a day, a computer (GitHub's automated
+pipeline, running in a Docker container) logs into these systems, pulls the
+latest data, generates the website pages, locks them with a password, and
+publishes the result to the web. You don't need to run anything yourself to
+see the current site.
+
+**How do I run it myself?** If you have the project on your computer and have
+been given the credentials file (`.Renviron`), type `make test` to check
+everything works, then `make serve` to view the site locally in your browser
+at <http://localhost:8000>. The [Makefile](Makefile) has seven commands, all
+starting with `make`, that cover testing, building, and serving — you will
+only ever need `make test` and `make serve` for day-to-day use.
+
+**What should I never do?** Never put real passwords or API tokens in a file
+that gets committed to the repository. The project has automated checks
+([RECORDING.md](RECORDING.md)) that refuse to merge anything containing a
+token-shaped string — keep credentials in `.Renviron`, which is never
+committed.


### PR DESCRIPTION
## Summary

Repo-level learn-the-repo skill at `.opencode/skills/abmdash-guide/SKILL.md` — a committed walkthrough grounded in docs/okf/ + vignettes + behavior-lock suite + Makefile, with source-of-truth accuracy (the OKF bundle is stale post-wave-3b). Dual audience: agent-facing (module map, symbols, test suite) + non-engineer plain-language section. NO debug-workflow section (AC-4.2 scope guard). `.Rbuildignore` gains `^.opencode$`.

## Issue
Closes #66

## ACs implemented
- [x] SKILL.md exists + git-tracked
- [x] Frontmatter: `name: abmdash-guide` + non-empty description (triggers on learn abmdash / how does this repo work / what modules / dashboard architecture)
- [x] Walkthrough covers purpose; architecture (build-image + build-dashboard CI, cron `0 6 * * *`, staticrypt); 10-module map; data sources; local run; behavior-lock location; verify-understanding step
- [x] ACCURACY: redcap_api = 16 internal helpers (25 top-level fns, 9 exported) — grounded count + stale-OKF note pointing to R/redcap_api.R
- [x] ACCURACY: 10 R files incl. week12_tracking.R (no unqualified "9 R files")
- [x] ACCURACY: 33 exports (counted from NAMESPACE)
- [x] Makefile: all 7 real targets referenced (test, test-trad, docker-build, docker-render, docker-test-auth, lint, serve); none invented
- [x] Behavior-lock-as-spec: references test-redcap-behavior-lock.R, test-snapshot-lock.R, helper-harness.R + RECORDING.md at repo ROOT; "the tests ARE the spec"
- [x] Dual audience: §7 verify-understanding + §8 non-engineer plain-language
- [x] All 41 repo-relative links resolve on disk (ground truth = filesystem)
- [x] NO debug-workflow top-level section
- [x] `.Rbuildignore` has `^.opencode$` placed after `^.codegraph$`

## Probe results (AC-4.1 executable spec)
```
$ git ls-files --error-unmatch .opencode/skills/abmdash-guide/SKILL.md
.opencode/skills/abmdash-guide/SKILL.md        # tracked ✓

$ head -12 .opencode/skills/abmdash-guide/SKILL.md
---                                  # frontmatter parses: name: abmdash-guide
name: abmdash-guide                   # description: non-empty, trigger-rich ✓
description: >- ...

$ grep -n "2 internal\|9 R files\|9 modules" SKILL.md
(no matches — exit 1)                 # stale-accuracy clauses ABSENT ✓

$ grep -n "16 internal\|10 R files\|33 exports" SKILL.md
94: **16 internal helpers** (25 top-level functions total, 9 exported) ✓
99: **10 R files**, not nine: ... week12_tracking.R ✓
102: **33 exports** total, as counted in NAMESPACE ✓

$ grep -c "0 6 * * *"   → 1      # cron ✓
$ grep -c "build-image" → 3      # CI job 1 ✓
$ grep -c "build-dashboard" → 9  # CI job 2 ✓
$ grep -c "staticrypt"  → 9      # encryption ✓
$ grep -c "RECORDING.md" → 2     # repo-root RECORDING ✓ (2 of 2 prose mentions)

# link-existence loop (python, ground truth = filesystem)
total links: 41
broken: 0                            # every markdown link target exists ✓

$ grep -n "^#.*[Dd]ebug" SKILL.md
(no matches — exit 1)                # no debug-workflow top-level section ✓

$ tail -2 .Rbuildignore
^\.codegraph$
^\.opencode$                         # placed after ^.codegraph$ ✓
```

## Test plan
- [x] Probe results above (verification: code + manual)
- [ ] PR review findings resolved
- Not a code change: no test suite run needed (pure documentation); R build ignores `.opencode/` via new `.Rbuildignore` entry.

## Self-Review
- [x] All ACs exercised by probe
- [x] Predicates match spec (12 conjuncts)
- [x] Negative case covered (no stale strings, no TOC-only, no debug section, frontmatter parses)
- [x] Verification medium satisfied (code + manual)
- [x] Design intent respected (§4 module-responsibility doc; source-of-truth over stale OKF)
- [x] No scope creep (single chore commit: skill + plan file + .Rbuildignore)
