### PR TITLE
[chore] Add debug workflows to abmdash-guide skill

### DIFF
--- a/.opencode/plans/repo-usability/AC-4.2.md
+++ b/.opencode/plans/repo-usability/AC-4.2.md
@@ -1,0 +1,46 @@
+---
+feature: repo-usability
+ac: 4.2
+status: complete
+title: "[chore] Add debug workflows to abmdash-guide skill"
+---
+
+# AC-4.2 — Debug workflows in abmdash-guide skill
+
+Slice from `repo-usability`. Issue #67. Spec block in issue body (13 conjuncts).
+
+## Progress
+
+- [x] 2026-08-13 — Read issue #67 + spec (13 conjuncts); plan file absent → spec carried in issue body (same as AC-4.1 precedent).
+- [x] 2026-08-13 — Ground-truth verification: Makefile `test` target = bare `devtools::test()` (no filter support); `test-trad` = `devtools::test(filter = "trad-compliance")` only filtered target. 18 test files under tests/testthat/. redcap_api.R lines 471/615/657 exact. gsheet env stop at :208 (not :163 — post-refactor drift), openssl::read_key at gsheet:267 / gcal:160 (not 188-189/118-119). test-abs-login.R:519 skip_if_not. FAQ 9 sections confirmed. CI jobs build-image → build-dashboard, secrets list, git pull --rebase.
+- [x] 2026-08-13 — Fixed two #68-review nits in SKILL.md: bare-directory link `(vignettes/)` → `(vignettes/faq.Rmd)`; `_snaps/snapshot-lock/` dir link → plain-code text; REDCap expanded at first use in non-engineer section.
+- [x] 2026-08-13 — Extended frontmatter description with debug triggers (debug/diagnose/probe/broken/error/symptom) WITHOUT removing learn-repo triggers.
+- [x] 2026-08-13 — Appended `## 9. Debug Workflows`: probing rules (make test filter= BAN, Rscript form, full filter strings, filter="compliance" = 3 files), canonical lock-suite-as-diagnostic text, creds+network WARNING block (docker-test-auth/docker-render/docker-build fenced), 18-row symptom→probe→likely-file table (16 spec entries + 2 closing FAQ §5/§6 gaps), CI job distinction, abs-login 1-skip disclosure.
+- [x] 2026-08-13 — Verification: filter-validity loop (every devtools::test filter matches a tests/testthat/ file), no make-test-filter as probe, no live R call probes, link-existence loop (30 links, 0 bad), path:line existence checks, PEM rg-false-zero confirmed, ran abs-login suite offline → 38 test_that / 1 skipped / 37 pass / 0 failures.
+- [x] 2026-08-13 — Committed, pushed, PR created with probe results in body.
+
+## Decision Log
+
+- **Post-refactor path:line over issue's stale lines**: issue Technical Context said gsheet:163 (env stop) and gsheet:188-189/gcal:118-119 (PEM) — those are PRE-refactor. Ground truth: gsheet:208, gsheet:267, gcal:160. Used actual lines (AC-7 "No stale names/lines" + design intent §4).
+- **18 rows not 16**: 16 spec entries verbatim + 2 supplementary rows (missing R package; enrollment_targets.csv) to close the FAQ §5/§6 gap in 9-cluster coverage (AC-11). Both probes verified real (`rg "package is required" R/`, `rg "enrollment_targets" R/run_initial_function.R`).
+- **PEM probe**: "Failed to parse private key PEM" is NOT a stop() string (openssl runtime) — probe = test(filter="google-token-signing"), explicitly noting rg returns zero. Confirmed zero matches in source.
+- **abs-login disclosure**: "green with 1 skip" — the single skip is the live-login test at :519; other 37 tests run offline (verified by executing the suite: 38 test_that, 1 skip, 37 pass).
+- **Snapshot-lock link**: made plain-code text rather than a file link (AC-4.1 already links the test file; avoids bare-directory link class).
+
+## Surprises & Discoveries
+
+- Plan file `.opencode/plans/repo-usability/AC-4.2.md` did not exist at branch creation — spec lives entirely in the issue body (same as AC-4.1). Not a blocker.
+- Issue's gsheet/gcal path:line claims (163/188-189/118-119) were stale post-refactor — actual env stop at gsheet:208, read_key at gsheet:267 / gcal:160. Grounded against source rather than trusting spec numbers.
+- abs-login suite has 38 test_that blocks (not "16 behavior-lock tests"); only 1 skips offline (the live-login manual test). Ran the suite to verify the claim before writing it.
+- `make test filter=X` doesn't "report filter unused" — make never passes it to devtools::test(); it silently runs the full suite. Wording corrected to match mechanics.
+
+## Verification Notes
+
+- Filter-validity loop: all 16 table filters match a tests/testthat/ file (redcap-behavior-lock, google-token-signing, gsheet-api, gcal-api, eligible-participants, snapshot-lock, faq-verbatim, trad-compliance, abs-login, fixture-scan-google, combined-calendar + 2 supplementary).
+- `make test filter=` appears only in ban text, never as a probe.
+- No live R calls as probes (abs_login(/download_abs_csv(/read_google_sheet( absent from probe column).
+- docker-test-auth/docker-render/docker-build only in WARNING block + pre-existing §5 table (AC-4.1 content).
+- Link-existence loop: 30 links, 0 broken.
+- Path:line existence: 471/615/657/267/160/208/90/104/519 all resolve.
+- abs-login offline run: 37 pass, 1 skip, 0 fail.
+- Probe outputs pasted into PR body.

--- a/.opencode/skills/abmdash-guide/SKILL.md
+++ b/.opencode/skills/abmdash-guide/SKILL.md
@@ -8,14 +8,16 @@ description: >-
   sources (REDCap, Google Sheets, Google Calendar, ABS portal), local run via
   the Makefile, and the behavior-lock test suite as executable specs. Use when
   someone asks to learn abmdash, understand how this repo works, what modules
-  exist, or how the dashboard architecture is put together.
+  exist, or how the dashboard architecture is put together. Also for
+  troubleshooting: debug, diagnose, probe, or investigate errors, broken
+  tests, failing CI, or reported symptoms — see the Debug workflows section.
 ---
 
 # abmdash — Learn the Repo
 
 A single-file orientation for anyone (agent or human) new to this repository.
 Read top to bottom once; then use the module map as a lookup table. For
-troubleshooting (not covered here) see the [troubleshooting vignettes](vignettes/).
+troubleshooting (not covered here) see the [troubleshooting vignettes](vignettes/faq.Rmd).
 
 ## 1. Repo Purpose
 
@@ -162,7 +164,7 @@ Entry points:
   empty-result and error branches, with no-token guards on every mock file.
 - [tests/testthat/test-snapshot-lock.R](tests/testthat/test-snapshot-lock.R) —
   snapshot-locking harness (`expect_snapshot_locked()`), pinned RDS files under
-  [tests/testthat/_snaps/snapshot-lock/](tests/testthat/_snaps/snapshot-lock/).
+  `tests/testthat/_snaps/snapshot-lock/`.
 - [tests/testthat/helper-harness.R](tests/testthat/helper-harness.R) —
   fixture loading (`load_fixture()`) and isolated-env helpers used by all tests.
 
@@ -202,7 +204,8 @@ automatically every time the site is rebuilt.
 **Where does the data come from?** Four places, all read automatically (nobody
 types numbers in by hand):
 
-- **REDCap** — the study's main database of participants and their progress.
+- **REDCap** (Research Electronic Data Capture — the study's main participant
+  database) — records participants and their progress.
 - **Google Sheets** — where weekly gameplay session data is logged.
 - **Google Calendar** — study events.
 - **The ABS portal** — an administrative website that records traditional ABM
@@ -226,3 +229,86 @@ that gets committed to the repository. The project has automated checks
 ([RECORDING.md](RECORDING.md)) that refuse to merge anything containing a
 token-shaped string — keep credentials in `.Renviron`, which is never
 committed.
+
+## 9. Debug Workflows
+
+Symptom → probe → likely-file diagnostics for the most common failures in
+this repo. **Every probe here is offline**: it is an `Rscript
+-e 'devtools::test(filter="...")'` run, a `make test-trad`, an `rg` over
+source, or a file existence check. Nothing below talks to a live API,
+needs credentials, or needs the network.
+
+### Probing rules — read this first
+
+- **Never run `make test filter=X`.** The Makefile `test` target is a bare
+  `devtools::test()` — it never reads `filter`, so `make test filter=X`
+  silently runs the **full suite**. Use
+  `Rscript -e 'devtools::test(filter="<name>")'` instead. `make test-trad`
+  is the **only** filtered make target (it wraps
+  `devtools::test(filter = "trad-compliance")`).
+- **Filters are substrings of test-file names — use full strings.**
+  `filter="compliance"` matches **three** files (`test-compliance-summary.R`,
+  `test-compliance-tracking.R`, `test-trad-compliance.R`) — over-match. Use
+  `filter="compliance-summary"` to pin one module.
+- **Every filter below matches a real `tests/testthat/` file** — if a filter
+  runs zero tests, the name is wrong, not the environment.
+
+Behavior-lock suites are executable docs:
+`Rscript -e 'devtools::test(filter="<name>")'`. Green = behavior LOCKED —
+bug is upstream (credentials, data shape, environment). Red = behavior
+CHANGED in code. Never use `make test filter=X` — Makefile test ignores
+filter, silently runs the full suite; `make test-trad` is the only filtered
+make target. Filters are substrings of test-file names — use full strings.
+
+> **⚠ Requires credentials AND network — do NOT use as probes.** `make
+> docker-test-auth` (needs `.Renviron` with `ABS_USERNAME`/`ABS_PASSWORD`,
+> plus network to the ABS portal) and `make docker-render` (needs all
+> credentials plus network for `renv::restore()` and quarto) verify real
+> integrations. `make docker-build` needs network (pulls base images) but no
+> credentials. These three are *verification* targets, never *diagnostic*
+> probes — if you need to debug, run the offline probes in the table below
+> first.
+
+### Symptom → probe → likely file
+
+| Symptom (verbatim error fragment) | Probe (offline) | Likely file |
+|---|---|---|
+| `row names contain missing values` | `Rscript -e 'devtools::test(filter="redcap-behavior-lock")'` | [R/redcap_api.R](R/redcap_api.R):471 (`get_eligible_participants`), :615 (`eligibility_mask`), :657 (`get_weekly_screening_stats`) |
+| `Failed to parse private key PEM` (openssl runtime string — NOT a `stop()` in source, so `rg` returns zero) | `Rscript -e 'devtools::test(filter="google-token-signing")'` | [R/gsheet_api.R](R/gsheet_api.R):267, [R/gcal_api.R](R/gcal_api.R):160 (`openssl::read_key`) |
+| `GOOGLE_SERVICE_ACCOUNT_JSON environment variable is not set or is empty` | `Rscript -e 'devtools::test(filter="gsheet-api")'` | [R/gsheet_api.R](R/gsheet_api.R):208 |
+| GCal event errors (token, parse, event shape) | `Rscript -e 'devtools::test(filter="gcal-api")'` | [R/gcal_api.R](R/gcal_api.R) |
+| REDCap fetch/parse errors | `Rscript -e 'devtools::test(filter="redcap-behavior-lock")'` | [R/redcap_api.R](R/redcap_api.R) |
+| Eligibility regressions | `Rscript -e 'devtools::test(filter="eligible-participants")'` | [R/redcap_api.R](R/redcap_api.R):471 |
+| Snapshot drift (pinned RDS changed) | `Rscript -e 'devtools::test(filter="snapshot-lock")'` | `tests/testthat/_snaps/snapshot-lock/` |
+| FAQ-quoted error string suspect | `Rscript -e 'devtools::test(filter="faq-verbatim")'` | [tests/testthat/test-faq-verbatim.R](tests/testthat/test-faq-verbatim.R) |
+| Trad-compliance regression | `make test-trad` | [R/trad_compliance.R](R/trad_compliance.R) |
+| ABS offline (login/download behavior) | `Rscript -e 'devtools::test(filter="abs-login")'` — green **with 1 skip** is the expected offline result | [tests/testthat/test-abs-login.R](tests/testthat/test-abs-login.R):519 (`skip_if_not`) |
+| CI `build-image` job red | inspect [Dockerfile](Dockerfile) + [renv.lock](renv.lock) — renv/base-image/network (CI cache is GHA's, not local `/tmp/docker-cache`) | [Dockerfile](Dockerfile), [renv.lock](renv.lock) |
+| CI `build-dashboard` job red | inspect secrets/render/rebase — [build-dashboard.sh](build-dashboard.sh) + [.github/workflows/build-dashboard.yml](.github/workflows/build-dashboard.yml) | [build-dashboard.sh](build-dashboard.sh), workflow |
+| `renv::restore()` fails/hangs | `rg "renv" Dockerfile renv.lock` | [Dockerfile](Dockerfile), [renv.lock](renv.lock) |
+| staticrypt error/absent password | `rg "staticrypt" build-dashboard.sh .github/workflows/build-dashboard.yml` | [build-dashboard.sh](build-dashboard.sh), workflow |
+| Fixture-scan violation (token-shaped string in fixtures) | `Rscript -e 'devtools::test(filter="fixture-scan-google")'` | [tests/testthat/test-fixture-scan-google.R](tests/testthat/test-fixture-scan-google.R) |
+| Calendar event order wrong | `Rscript -e 'devtools::test(filter="combined-calendar")'` | [R/gcal_api.R](R/gcal_api.R) |
+| Missing R package (`httr2`/`jsonlite`/`jose` — `... package is required`) | `rg "package is required" R/` | [R/gsheet_api.R](R/gsheet_api.R):37/41/202, [R/gcal_api.R](R/gcal_api.R):32/36/121/208/212, [R/abs_login.R](R/abs_login.R):24, [R/redcap_api.R](R/redcap_api.R):40 |
+| `Could not find enrollment_targets.csv file` | `rg "enrollment_targets" R/run_initial_function.R` | [R/run_initial_function.R](R/run_initial_function.R):90-104, [inst/extdata/enrollment_targets.csv](inst/extdata/enrollment_targets.csv) |
+
+### CI job distinction
+
+The two CI jobs fail for **different** reasons — do not conflate them:
+
+- **`build-image`** (first job): builds the Docker image. Reds come from
+  `renv::restore()` (lockfile drift, missing package, network), the base
+  image, or Docker layer cache. CI uses **GitHub Actions cache**, not the
+  local `/tmp/docker-cache` that `make docker-build` uses.
+- **`build-dashboard`** (needs `build-image`): render + encrypt + commit.
+  Reds come from secrets (missing/wrong env vars), the render step, or the
+  `git pull --rebase` in [build-dashboard.sh](build-dashboard.sh).
+
+### abs-login offline skip disclosure
+
+`tests/testthat/test-abs-login.R:519` has
+`skip_if_not(Sys.getenv("ABS_USERNAME") != "" && Sys.getenv("ABS_PASSWORD") != "")`.
+Offline (no `.Renviron` credentials) **"green with 1 skip" is the expected
+result** — it is NOT a failure and NOT "all pass". The skip is the single
+live-login test (line 519); the other 37 tests in the file still run and
+pin the recorded-fixture behavior.


### PR DESCRIPTION
## Summary
Append a `## 9. Debug Workflows` section to the repo-level `.opencode/skills/abmdash-guide/SKILL.md` (AC-4.1 scaffold): symptom → probe → likely-file diagnostics with offline-only probes. Extends the frontmatter description with debug triggers (append-only — learn-repo triggers preserved). Also fixes two nits from the #68 review.

## Issue
Closes #67

## ACs implemented
- [x] SKILL.md debug section (symptom→probe→likely-file structure)
- [x] Probe existence: every probe = real Makefile target / `Rscript devtools::test(filter=<real test file>)` / rg pattern / existing path
- [x] `make test filter=` sneaky-pass BAN: `Rscript -e 'devtools::test(filter="...")'` taught, full filter strings (`filter="compliance"` matches 3 files)
- [x] Offline guarantee: docker-test-auth/docker-render/docker-build fenced in "requires credentials + network" WARNING, never probes; no live R calls as probes
- [x] Lock-suite-as-diagnostic canonical text (Rscript form, green=locked/red=changed)
- [x] abs-login 1-skip disclosure (test-abs-login.R:519) — "green with 1 skip" expected offline
- [x] Post-refactor mapping: row-names → redcap_api.R:471/615/657 (verified exact)
- [x] CI job distinction: build-image (renv/base/network, GHA cache) vs build-dashboard (secrets/render/rebase)
- [x] Discovery: frontmatter description contains debug|troubleshoot|diagnose|probe|symptom — extends AC-4.1, doesn't replace
- [x] AC-4.1 preservation: learn-repo content intact (append-only + 2 mandated nit edits)
- [x] 9-cluster coverage: all FAQ verbatim error classes + CI reds + renv + staticrypt have entries
- [x] No generic-only advice: every probe repo-specific
- [x] "Failed to parse private key PEM" = openssl runtime string → probe `test(filter="google-token-signing")`, NOT rg (verified zero matches in source)

## Nits from #68 review (fixed in same edit)
- `(vignettes/)` → `(vignettes/faq.Rmd)`; snapshot-lock dir link → plain code text
- REDCap expanded at first use in non-engineer section

## Test plan
### Probe results (verification: code + manual)
- **Filter-validity loop** — every `devtools::test` filter matches a `tests/testthat/` file:
  ```
  abs-login -> test-abs-login.R; combined-calendar -> test-combined-calendar.R
  eligible-participants -> test-eligible-participants.R; faq-verbatim -> test-faq-verbatim.R
  fixture-scan-google -> test-fixture-scan-google.R; gcal-api -> test-gcal-api.R
  google-token-signing -> test-google-token-signing.R; gsheet-api -> test-gsheet-api.R
  redcap-behavior-lock -> test-redcap-behavior-lock.R; snapshot-lock -> test-snapshot-lock.R
  run-initial-function -> test-run-initial-function.R; trad-compliance -> test-trad-compliance.R
  compliance -> 3 files (compliance-summary, compliance-tracking, trad-compliance) — over-match taught
  ```
- **No make-test-filter as probe**: `make test filter=` appears only in ban text (2 occurrences, both prohibitions)
- **No live R call probes**: `abs_login(`, `download_abs_csv(`, `read_google_sheet(` absent from probe column
- **docker targets**: docker-test-auth/docker-render/docker-build only in WARNING block (plus pre-existing §5 table, AC-4.1 content)
- **Link-existence loop**: 30 markdown links, 0 broken targets
- **Path:line existence**: redcap_api.R:471/615/657, gsheet_api.R:208/267, gcal_api.R:160, run_initial_function.R:90/104, test-abs-login.R:519 — all resolve
- **PEM rg false-zero**: `rg "Failed to parse private key PEM"` across R/, .github/, scripts → zero (openssl runtime string, not stop())
- **abs-login suite run offline** (38 test_that): 37 pass, 1 skip (live-login test at :519), 0 failures — "green with 1 skip" confirmed

### Deviations from issue Technical Context
1. **gsheet/gcal path:line corrected post-refactor**: issue listed gsheet:163 (env stop), gsheet:188-189/gcal:118-119 (PEM) — these are pre-refactor. Ground truth: env stop `R/gsheet_api.R:208`, `openssl::read_key` at `R/gsheet_api.R:267` / `R/gcal_api.R:160`. Used actual lines (AC-7 "no stale names/lines").
2. **18 rows, not 16**: the 16 spec entries verbatim + 2 supplementary rows (missing R package; enrollment_targets.csv) to close the FAQ §5/§6 gap in 9-cluster coverage (AC-11). Both probes verified real.
3. **Snapshot-lock "likely file"** rendered as plain code text (dir), not a link — avoids the bare-directory-link class flagged in #68.

- [ ] PR review findings resolved (pending)

## Self-Review
- [x] All ACs exercised by tests (verification = code + manual)
- [x] Predicates match spec
- [x] Negative case tested (make-test-filter absent as probe; no live calls; PEM rg zero)
- [x] Verification medium satisfied
- [x] Design intent respected (§4 header declares debug coverage + NOT-credential-required)
- [x] No scope creep